### PR TITLE
Dynamically get the latest LTS release version number 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ source ~/.local/share/omakub/ascii.sh
 
 # Needed for all installers
 sudo apt update -y
-sudo apt install -y curl git
+sudo apt install -y curl git jq
 
 # Ensure computer doesn't go to sleep while installing
 gsettings set org.gnome.desktop.session idle-delay 0

--- a/install/nodenv.sh
+++ b/install/nodenv.sh
@@ -1,5 +1,5 @@
 if ! command -v nodenv &>/dev/null; then
-	URL=https://nodejs.org/download/release/index.json
+	URL="https://nodejs.org/download/release/index.json"
 	DEFAULT_NODE_VERSION=$(curl -s "$URL" | jq -r '.[] | select(.lts != false) | .version' | head -n 1)
 
 	git clone https://github.com/nodenv/nodenv.git ~/.nodenv

--- a/install/nodenv.sh
+++ b/install/nodenv.sh
@@ -1,6 +1,6 @@
 if ! command -v nodenv &>/dev/null; then
 	URL=https://nodejs.org/download/release/index.json
-	DEFAULT_NODE_VERSION=(curl -s "$URL" | jq -r '.[] | select(.lts != false) | .version' | head -n 1)
+	DEFAULT_NODE_VERSION=$(curl -s "$URL" | jq -r '.[] | select(.lts != false) | .version' | head -n 1)
 
 	git clone https://github.com/nodenv/nodenv.git ~/.nodenv
 	sudo ln -vs ~/.nodenv/bin/nodenv /usr/local/bin/nodenv

--- a/install/nodenv.sh
+++ b/install/nodenv.sh
@@ -1,6 +1,6 @@
 if ! command -v nodenv &>/dev/null; then
-	# FIXME: Make this pick whatever the latest LTS is
-	DEFAULT_NODE_VERSION="20.13.1"
+	URL=https://nodejs.org/download/release/index.json
+	DEFAULT_NODE_VERSION=(curl -s "$URL" | jq -r '.[] | select(.lts != false) | .version' | head -n 1)
 
 	git clone https://github.com/nodenv/nodenv.git ~/.nodenv
 	sudo ln -vs ~/.nodenv/bin/nodenv /usr/local/bin/nodenv


### PR DESCRIPTION
I noticed as the script right now , the node version is manually inputted. 
Since node supplies a index.json file [here](https://nodejs.org/download/release/) which happens to be neatly arranged by version number, we can probably get the latest LTS release version by checking the first entry which has its LTS key set to something other than false with jq.