### PR TITLE
Use typora.io gpg key

### DIFF
--- a/install/app-typora.sh
+++ b/install/app-typora.sh
@@ -1,4 +1,4 @@
-wget -qO - https://typoraio.cn/linux/public-key.asc | sudo tee /etc/apt/trusted.gpg.d/typora.asc
+wget -qO - https://typora.io/linux/public-key.asc | sudo tee /etc/apt/trusted.gpg.d/typora.asc
 sudo add-apt-repository 'deb https://typora.io/linux ./'
 sudo apt update
 sudo apt install -y typora


### PR DESCRIPTION
typoraio.cn hangs for me, the deb repo is using typora.io anyway and the typora.io website uses that domain as the one hosting the gpg key