### PR TITLE
Adds unzip dependency required by install/fonts.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ source ~/.local/share/omakub/ascii.sh
 
 # Needed for all installers
 sudo apt update -y
-sudo apt install -y curl git jq
+sudo apt install -y curl git jq unzip
 
 # Ensure computer doesn't go to sleep while installing
 gsettings set org.gnome.desktop.session idle-delay 0


### PR DESCRIPTION
This might already be a required by one of the packages on Ubuntu 24.04 but in my Ubuntu 22.04 WSL2 trial unzip wasn't available when it was needed.