### PR TITLE
Fix background copying bug

### DIFF
--- a/themes/gnome/_set-gnome-theme.sh
+++ b/themes/gnome/_set-gnome-theme.sh
@@ -4,7 +4,11 @@ gsettings set org.gnome.desktop.interface gtk-theme "Yaru-$OMAKUB_THEME_COLOR-da
 gsettings set org.gnome.desktop.interface icon-theme "Yaru-$OMAKUB_THEME_COLOR"
 
 BACKGROUND_ORG_PATH="$HOME/.local/share/omakub/backgrounds/$OMAKUB_THEME_BACKGROUND"
-BACKGROUND_DEST_PATH="$HOME/.local/share/backgrounds/$OMAKUB_THEME_BACKGROUND"
+BACKGROUND_DEST_DIR="$HOME/.local/share/backgrounds"
+BACKGROUND_DEST_PATH="$BACKGROUND_DEST_DIR/$OMAKUB_THEME_BACKGROUND"
+
+if [ ! -d "$BACKGROUND_DEST_DIR" ]; then mkdir -p "$BACKGROUND_DEST_DIR"; fi
+
 [ ! -f $BACKGROUND_DEST_PATH ] && cp $BACKGROUND_ORG_PATH $BACKGROUND_DEST_PATH
 gsettings set org.gnome.desktop.background picture-uri $BACKGROUND_DEST_PATH
 gsettings set org.gnome.desktop.background picture-uri-dark $BACKGROUND_DEST_PATH


### PR DESCRIPTION
If the `$HOME/.local/share/backgrounds` directory doesn't exist (eg on a fresh install of Ubuntu 24.04) the background wallpaper can't be copied across when choosing a theme.

This fix creates the directory if it doesn't exist.