### PR TITLE
Installation: restore 'idle-delay' setting instead of defaulting it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,14 +5,17 @@ source ~/.local/share/omakub/ascii.sh
 sudo apt update -y
 sudo apt install -y curl git jq unzip
 
+# Get the current idle-delay, to restore it later
+IDLE_DELAY=$(gsettings get org.gnome.desktop.session idle-delay | cut -d " " -f 2)
+
 # Ensure computer doesn't go to sleep while installing
 gsettings set org.gnome.desktop.session idle-delay 0
 
 # Run installers
 for script in ~/.local/share/omakub/install/*.sh; do source $script; done
 
-# Revert to normal idle settings
-gsettings set org.gnome.desktop.session idle-delay 300
+# Revert to previous idle settings
+gsettings set org.gnome.desktop.session idle-delay "$IDLE_DELAY"
 
 # Upgrade everything that might ask for a reboot last
 sudo apt upgrade -y


### PR DESCRIPTION
This resets the 'idle-delay' value to the previous value, respecting the uses settings, instead of defaulting to another specific value (300).

This is much more reasonable, since some user might have already changed that and then the installation just changes that, which is not a good thing to do in silence.

It is not that hard to save the original value before the installation and restoring it after

`gsettings get org.gnome.desktop.session idle-delay` returns a variant in the form of `<type> <value>` therefore we need to only store the second part, for which I use cut, since as far as I know, it is always preinstalled (you could use `awk` or other things, but why not go with the easiest tool to complete the job?)