### PR TITLE
Add missing sudo in mise install script

### DIFF
--- a/install/mise.sh
+++ b/install/mise.sh
@@ -1,5 +1,5 @@
 # Install mise for managing multiple versions of languages. See https://mise.jdx.dev/
-sudo apt update -y && apt install -y gpg sudo wget curl
+sudo apt update -y && sudo apt install -y gpg sudo wget curl
 sudo install -dm 755 /etc/apt/keyrings
 wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | sudo tee /etc/apt/keyrings/mise-archive-keyring.gpg 1>/dev/null
 echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list


### PR DESCRIPTION
`sudo` is missing in the `apt install` command in `mise.sh` script, which leads to packages not being installed and errors in the output

```
E: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)
E: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?
```