### PR TITLE
Exit on error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 # Be fancy
 source ~/.local/share/omakub/ascii.sh
 
+# Exit immediately if a command exits with a non-zero status
+set -e
+
 # Needed for all installers
 sudo apt update -y
 sudo apt install -y curl git unzip


### PR DESCRIPTION
If any of the (sub)commands in `install.sh` fail, the install script will continue to run and effectively hide the fact that something went wrong. Setting `set -e` will make the bash script exit upon an error. 


Context: I was just testing #29 in an `arm64` VM, and the installation of `mise` failed silently (because the current version does not have a code path for `arm64`); however, it appeared as if the installation had worked correctly and I got logged out at the end of it. 
Then, when I tried to log in again, the system would simply hang. Upon further inspection, I realized it was hanging on this prompt:

https://github.com/basecamp/omakub/blob/9c603cd1f72be4c8c1e4b02f2f12ac39359e81a4/defaults/bash/init#L4

<img width="421" alt="Screenshot 2024-06-08 at 11 08 22 AM" src="https://github.com/basecamp/omakub/assets/205556/714e06eb-daaf-49cd-8f47-973e75cb6f75">
