### PR TITLE
fix: use soft-wrap to show all help content

### DIFF
--- a/bin/omakub-help
+++ b/bin/omakub-help
@@ -1,2 +1,2 @@
 HELP=$(gum choose "Hotkeys" "Commands" "Tactile" --header "What do you need help with?" --height 5 | tr '[:upper:]' '[:lower:]')
-[ -n "$HELP" ] && gum pager <$OMAKUB_PATH/help/$HELP.md
+[ -n "$HELP" ] && gum pager --soft-wrap <$OMAKUB_PATH/help/$HELP.md

--- a/help/commands.md
+++ b/help/commands.md
@@ -1,6 +1,6 @@
 # Commands
 
-Omakub installs a host of modern commands that improve on the Linux stables. You should eventually read up on all eza, fzf, zoxide, bat has to offer. But here are the most important ways. 
+Omakub installs a host of modern commands that improve on the Linux stables. You should eventually read up on all eza, fzf, zoxide, bat has to offer.But here are the most important ways.
 
 | Command                   | Function                                    |
 | ------------------------- | ------------------------------------------- |

--- a/help/commands.md
+++ b/help/commands.md
@@ -1,6 +1,6 @@
 # Commands
 
-Omakub installs a host of modern commands that improve on the Linux stables. You should eventually read up on all eza, fzf, zoxide, bat has to offer.But here are the most important ways. 
+Omakub installs a host of modern commands that improve on the Linux stables. You should eventually read up on all eza, fzf, zoxide, bat has to offer. But here are the most important ways. 
 
 | Command                   | Function                                    |
 | ------------------------- | ------------------------------------------- |

--- a/help/tactile.md
+++ b/help/tactile.md
@@ -1,19 +1,10 @@
 # Tactile
 
-Tactile is a tool for tiling windows on larger displays. It's not a tiling windows manager, like i3 or Hyprland,
-so it works alongside the regular Ubuntu Gnome window system that anyone coming from Windows or Mac would be 
-familiar with. By default, Omakub has configured it with 6 slots, using one main column, and two wings. This is
-a great setup for having your editor in the center, flanked by docs and browser and AI helpers and what else.
+Tactile is a tool for tiling windows on larger displays. It's not a tiling windows manager, like i3 or Hyprland, so it works alongside the regular Ubuntu Gnome window system that anyone coming from Windows or Mac would be familiar with. By default, Omakub has configured it with 6 slots, using one main column, and two wings. This is a great setup for having your editor in the center, flanked by docs and browser and AI helpers and what else.
 
-You don't need or probably even want to use this when using a smaller laptop, like a Framework 13. On a screen 
-like that, you're better off either using your applications full-screen and switching between workspaces, or 
-just using the two-way default Gnome tiling. Super+<arrow left> and Super+<arrow right> controls the default 
-Gnome window tiler, putting the active application on either the left or the right. Super+<arrow up> will 
-maximize the application. And, finally, F11 takes an application full screen.
+You don't need or probably even want to use this when using a smaller laptop, like a Framework 13. On a screen like that, you're better off either using your applications full-screen and switching between workspaces, or just using the two-way default Gnome tiling. Super+<arrow left> and Super+<arrow right> controls the default Gnome window tiler, putting the active application on either the left or the right. Super+<arrow up> will maximize the application. And, finally, F11 takes an application full screen.
 
-But when you are on that big scren, use Tactile with Super+T to bring up the tiling overview. Then press W+S 
-to make the application take up the two center slots. You can also do Super+Q+Q to take up just the Q slot in 
-the upper left slot. Or even Super+Q+S to take up the four slots on the left of the screen.
+But when you are on that big screen, use Tactile with Super+T to bring up the tiling overview. Then press W+S to make the application take up the two center slots. You can also do Super+Q+Q to take up just the Q slot in the upper left slot. Or even Super+Q+S to take up the four slots on the left of the screen.
 
 ## Hotkeys
 

--- a/help/tactile.md
+++ b/help/tactile.md
@@ -1,10 +1,19 @@
 # Tactile
 
-Tactile is a tool for tiling windows on larger displays. It's not a tiling windows manager, like i3 or Hyprland, so it works alongside the regular Ubuntu Gnome window system that anyone coming from Windows or Mac would be familiar with. By default, Omakub has configured it with 6 slots, using one main column, and two wings. This is a great setup for having your editor in the center, flanked by docs and browser and AI helpers and what else.
+Tactile is a tool for tiling windows on larger displays. It's not a tiling windows manager, like i3 or Hyprland,
+so it works alongside the regular Ubuntu Gnome window system that anyone coming from Windows or Mac would be 
+familiar with. By default, Omakub has configured it with 6 slots, using one main column, and two wings. This is
+a great setup for having your editor in the center, flanked by docs and browser and AI helpers and what else.
 
-You don't need or probably even want to use this when using a smaller laptop, like a Framework 13. On a screen like that, you're better off either using your applications full-screen and switching between workspaces, or just using the two-way default Gnome tiling. Super+<arrow left> and Super+<arrow right> controls the default Gnome window tiler, putting the active application on either the left or the right. Super+<arrow up> will maximize the application. And, finally, F11 takes an application full screen.
+You don't need or probably even want to use this when using a smaller laptop, like a Framework 13. On a screen 
+like that, you're better off either using your applications full-screen and switching between workspaces, or 
+just using the two-way default Gnome tiling. Super+<arrow left> and Super+<arrow right> controls the default 
+Gnome window tiler, putting the active application on either the left or the right. Super+<arrow up> will 
+maximize the application. And, finally, F11 takes an application full screen.
 
-But when you are on that big screen, use Tactile with Super+T to bring up the tiling overview. Then press W+S to make the application take up the two center slots. You can also do Super+Q+Q to take up just the Q slot in the upper left slot. Or even Super+Q+S to take up the four slots on the left of the screen.
+But when you are on that big screen, use Tactile with Super+T to bring up the tiling overview. Then press W+S 
+to make the application take up the two center slots. You can also do Super+Q+Q to take up just the Q slot in 
+the upper left slot. Or even Super+Q+S to take up the four slots on the left of the screen.
 
 ## Hotkeys
 


### PR DESCRIPTION
Had some issues on my laptop screen showing the full output for all content on the help pages.

This PR adds the `--soft-wrap` arg to [`gum pager` ](https://github.com/charmbracelet/gum/tree/main?tab=readme-ov-file#pager) to always show the full line content.

## Before

(Using a 1/2 split on a 14" 1920x1080 laptop)

![image](https://github.com/basecamp/omakub/assets/10927304/dc046419-73d7-4332-9812-82b7b24d62be)

## After

![image](https://github.com/basecamp/omakub/assets/10927304/712a1a5e-324a-4b45-ae64-ad39cc93d87a)

