### PR TITLE
Update: alacritty default font size from 7 to 10

### DIFF
--- a/configs/alacritty.toml
+++ b/configs/alacritty.toml
@@ -1,4 +1,4 @@
 import = [ "~/.config/alacritty/theme.toml", "~/.config/alacritty/font.toml", "~/.local/share/omakub/defaults/alacritty.toml" ]
 
 [font]
-size = 7
+size = 10


### PR DESCRIPTION
font size of 7 is too small for a default value, 10 is more reasonable