### PR TITLE
fix: Enable lockscreen once finished & update: set sudo editor

### DIFF
--- a/configs/bashrc
+++ b/configs/bashrc
@@ -2,3 +2,4 @@ source ~/.local/share/omakub/defaults/bash/rc
 
 # Editor used by CLI
 export EDITOR="nvim"
+export SUDO_EDITOR="nvim"

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ for script in ~/.local/share/omakub/install/*.sh; do source $script; done
 sudo apt upgrade -y
 
 # Revert to normal idle and lock settings
-gsettings set org.gnome.desktop.screensaver lock-enabled false
+gsettings set org.gnome.desktop.screensaver lock-enabled true
 gsettings set org.gnome.desktop.session idle-delay 300
 
 # Logout to pickup changes


### PR DESCRIPTION
Just fixing a small little error in the install & adding  `export SUDO_EDITOR` to bashrc to allow users to use their own neovim config when editting files with sudo by running `sudoedit`!