### PR TITLE
Add postgres container and docker group

### DIFF
--- a/install/docker.sh
+++ b/install/docker.sh
@@ -1,4 +1,5 @@
 sudo apt install -y docker.io docker-buildx
+sudo groupadd docker
 sudo usermod -aG docker ${USER}
 
 DOCKER_COMPOSE_VERSION="2.27.0"
@@ -7,6 +8,6 @@ mkdir -p $DOCKER_CONFIG/cli-plugins
 curl -sSL https://github.com/docker/compose/releases/download/v$DOCKER_COMPOSE_VERSION/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
 chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 
-# FIXME: Add postgresql as a default configured DB as well
 sudo docker create --restart unless-stopped -p 3306:3306 --name=mysql8 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8
 sudo docker create --restart unless-stopped -p 6379:6379 --name=redis redis
+sudo docker create --restart unless-stopped -p 5432:5432 --name=postgres16 -e POSTGRES_HOST_AUTH_METHOD=trust postgres16


### PR DESCRIPTION
Adds the docker group to ensure it exists and also runs a default postgres16 container without a password using `POSTGRES_HOST_AUTH_METHOD=trust`