### PR TITLE
Make neovim background transparent for catppuccin and tokyo-night

### DIFF
--- a/themes/neovim/catppuccin.lua
+++ b/themes/neovim/catppuccin.lua
@@ -1,5 +1,11 @@
 return {
 	{
+		"catppuccin",
+		opts = {
+			transparent_background = true,
+		},
+	},
+	{
 		"LazyVim/LazyVim",
 		opts = {
 			colorscheme = "catppuccin",

--- a/themes/neovim/tokyo-night.lua
+++ b/themes/neovim/tokyo-night.lua
@@ -5,4 +5,14 @@ return {
 			colorscheme = "tokyonight",
 		},
 	},
+	{
+		"folke/tokyonight.nvim",
+		opts = {
+			transparent = true,
+			styles = {
+				sidebars = "transparent",
+				floats = "transparent",
+			},
+		},
+	},
 }


### PR DESCRIPTION
As DHH mentions in #64, neovim's background could be transparent given the 97% opacity in alacritty. I did that in my config already.
This PR addresses transparency for tokyo-night and catppuccin. In light themes, it decreases readability for me personally.
