### PR TITLE
Transparent Neovim background for all themes

### DIFF
--- a/install/app-neovim.sh
+++ b/install/app-neovim.sh
@@ -4,5 +4,6 @@ sudo apt install -y neovim
 
 if [ ! -d "$HOME/.config/nvim" ]; then
 	git clone https://github.com/LazyVim/starter ~/.config/nvim
+	cp ~/.local/share/omakub/themes/neovim/commons.lua ~/.config/nvim/lua/plugins/
 	cp ~/.local/share/omakub/themes/neovim/tokyo-night.lua ~/.config/nvim/lua/plugins/theme.lua
 fi

--- a/themes/neovim/catppuccin.lua
+++ b/themes/neovim/catppuccin.lua
@@ -4,6 +4,7 @@ return {
 		opts = {
 			transparent_background = true,
 		},
+		config = require('plugins.commons').set_transparent_bg()
 	},
 	{
 		"LazyVim/LazyVim",

--- a/themes/neovim/commons.lua
+++ b/themes/neovim/commons.lua
@@ -1,0 +1,31 @@
+local commons = {}
+
+commons.set_transparent_bg = function()
+    -- transparent background
+    vim.api.nvim_set_hl(0, 'Normal', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NormalFloat', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'FloatBorder', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'Pmenu', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'Terminal', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'EndOfBuffer', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'FoldColumn', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'Folded', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'SignColumn', { bg = 'none' })
+
+    -- transparent background for neotree
+    vim.api.nvim_set_hl(0, 'NeoTreeNormal', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NeoTreeNormalNC', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NeoTreeVertSplit', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NeoTreeWinSeparator', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NeoTreeEndOfBuffer', { bg = 'none' })
+
+    -- transparent background for nvim-tree
+    vim.api.nvim_set_hl(0, 'NvimTreeNormal', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NvimTreeVertSplit', { bg = 'none' })
+    vim.api.nvim_set_hl(0, 'NvimTreeEndOfBuffer', { bg = 'none' })
+
+    -- hides `~` at the end of the buffer
+    vim.cmd([[set fillchars+=eob:\ ]])
+end
+
+return commons

--- a/themes/neovim/everforest.lua
+++ b/themes/neovim/everforest.lua
@@ -6,5 +6,6 @@ return {
 			colorscheme = "everforest",
 			background = "soft",
 		},
+		config = require('plugins.commons').set_transparent_bg()
 	},
 }

--- a/themes/neovim/gruvbox.lua
+++ b/themes/neovim/gruvbox.lua
@@ -5,5 +5,6 @@ return {
 		opts = {
 			colorscheme = "gruvbox",
 		},
+		config = require('plugins.commons').set_transparent_bg()
 	},
 }

--- a/themes/neovim/kanagawa.lua
+++ b/themes/neovim/kanagawa.lua
@@ -5,5 +5,6 @@ return {
 		opts = {
 			colorscheme = "kanagawa",
 		},
+		config = require('plugins.commons').set_transparent_bg()
 	},
 }

--- a/themes/neovim/nord.lua
+++ b/themes/neovim/nord.lua
@@ -5,5 +5,6 @@ return {
 		opts = {
 			colorscheme = "nord",
 		},
+		config = require('plugins.commons').set_transparent_bg()
 	},
 }

--- a/themes/neovim/rose-pine.lua
+++ b/themes/neovim/rose-pine.lua
@@ -5,5 +5,6 @@ return {
 		opts = {
 			colorscheme = "rose-pine-dawn",
 		},
+		config = require('plugins.commons').set_transparent_bg()
 	},
 }

--- a/themes/neovim/tokyo-night.lua
+++ b/themes/neovim/tokyo-night.lua
@@ -13,6 +13,7 @@ return {
 				sidebars = "transparent",
 				floats = "transparent",
 			},
+		config = require('plugins.commons').set_transparent_bg()
 		},
 	},
 }


### PR DESCRIPTION
As mentioned in https://github.com/basecamp/omakub/issues/64 we want to make neovim background transparent.

https://github.com/basecamp/omakub/pull/67 addresses this for catpuccin and tokyonight.

The solution proposed in this PR applies the same logic to all themes, regardless of their support for a transparent option.

This is achieved by utilizing highlight groups to set the background color to `none` for specific groups.

