### PR TITLE
Update docker.sh

### DIFF
--- a/install/docker.sh
+++ b/install/docker.sh
@@ -2,12 +2,15 @@ sudo apt install -y docker.io docker-buildx
 sudo groupadd docker
 sudo usermod -aG docker ${USER}
 
+# Limit log size to avoid running out of disk
+echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json
+
 DOCKER_COMPOSE_VERSION="2.27.0"
 DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
 mkdir -p $DOCKER_CONFIG/cli-plugins
 curl -sSL https://github.com/docker/compose/releases/download/v$DOCKER_COMPOSE_VERSION/docker-compose-linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
 chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
 
-sudo docker create --restart unless-stopped -p 3306:3306 --name=mysql8 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8
-sudo docker create --restart unless-stopped -p 6379:6379 --name=redis redis
-sudo docker create --restart unless-stopped -p 5432:5432 --name=postgres16 -e POSTGRES_HOST_AUTH_METHOD=trust postgres16
+sudo docker create --restart unless-stopped -p "127.0.0.1:3306:3306" --name=mysql8 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.4
+sudo docker create --restart unless-stopped -p "127.0.0.1:6379:6379" --name=redis redis:7
+sudo docker create --restart unless-stopped -p "127.0.0.1:5432:5432" --name=postgres16 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:16


### PR DESCRIPTION
- Feat: Limit log size to avoid running out of disk
- Feat: Limit export ports to localhost, by default are visible to entire network
- Bug: Prevent image update by setting a version, because downgrade is not possible for mysql
- Bug: Wrong postgres image name