### PR TITLE
Configure for Go development

### DIFF
--- a/configs/lazyvim.json
+++ b/configs/lazyvim.json
@@ -1,0 +1,4 @@
+{
+  "extras": [ "lazyvim.plugins.extras.lang.go" ],
+  "version": 6
+}

--- a/install/app-neovim.sh
+++ b/install/app-neovim.sh
@@ -5,4 +5,7 @@ sudo apt install -y neovim
 if [ ! -d "$HOME/.config/nvim" ]; then
 	git clone https://github.com/LazyVim/starter ~/.config/nvim
 	cp ~/.local/share/omakub/themes/neovim/tokyo-night.lua ~/.config/nvim/lua/plugins/theme.lua
+
+	# Enable default extras
+	cp ~/.local/share/omakub/configs/lazyvim.json ~/.config/nvim/lazyvim.json
 fi

--- a/install/app-vscode.sh
+++ b/install/app-vscode.sh
@@ -9,3 +9,6 @@ cp ~/.local/share/omakub/configs/vscode.json ~/.config/Code/User/settings.json
 
 # Install default supported themes
 code --install-extension enkia.tokyo-night
+
+# Install default language extensions
+code --install-extension golang.go

--- a/install/mise.sh
+++ b/install/mise.sh
@@ -9,3 +9,4 @@ sudo apt install -y mise
 # Install default languages
 mise use --global ruby@3.3
 mise use --global node@lts
+mise use --global go@latest


### PR DESCRIPTION
Adds some configuration so that Go development is set up out of the box:

- Installs latest Go via mise
- Enables the Go Extra in LazyVim by default
- Enables the Go plugin in VSCode by default