### PR TITLE
fix typo in alacritty config: "none" --> "None"

### DIFF
--- a/defaults/alacritty.toml
+++ b/defaults/alacritty.toml
@@ -7,7 +7,7 @@ program = "zellij"
 [window]
 padding.x = 16
 padding.y = 14
-decorations = "none"
+decorations = "None"
 opacity = 0.97
 
 [keyboard]


### PR DESCRIPTION
Config should say "None" (see below) instead of "none"

![alacrity-config-decorations](https://github.com/basecamp/omakub/assets/40115969/4b223a21-eede-443a-982b-d676d743d81d)


PS: Thank you for this great project!