### PR TITLE
Add option to select different prompt types

### DIFF
--- a/bin/omakub
+++ b/bin/omakub
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-source $OMAKUB_PATH/ascii.sh
+source "$OMAKUB_PATH/ascii.sh"
 
 if [ $# -eq 0 ]; then
-	SUB=$(gum choose "Help" "Theme" "Font" "Install" "Update" --height 8 --header "" | tr '[:upper:]' '[:lower:]')
+	SUB=$(gum choose "Help" "Theme" "Font" "Prompt" "Install" "Update" --height 8 --header "" | tr '[:upper:]' '[:lower:]')
 else
 	SUB=$1
 fi
 
-[ -n "$SUB" ] && source $OMAKUB_PATH/bin/omakub-$SUB
+[ -n "$SUB" ] && source "$OMAKUB_PATH/bin/omakub-$SUB"

--- a/bin/omakub-prompt
+++ b/bin/omakub-prompt
@@ -1,0 +1,19 @@
+# Pick a preconfigured prompt
+PROMT_NAMES=("Default" "Avatar")
+PROMPT=$(gum choose "${PROMT_NAMES[@]}" --header "Choose your prompt" --height 9 | tr '[:upper:]' '[:lower:]' | sed 's/ /_/g')
+
+# Exit if a prompt is not selected
+[ ! -n "$PROMPT" ] && exit 0
+
+# Reset current prompts
+unset PROMPT_COMMAND
+unset PS1
+unset PS2
+
+# Configure new prompt files
+PROMPT_FILE="$OMAKUB_PATH/prompts/$PROMPT.sh"
+OMAKUB_PROMPT_FILE="$OMAKUB_PATH/defaults/bash/prompt"
+
+cp $PROMPT_FILE $OMAKUB_PROMPT_FILE
+
+source $OMAKUB_PATH/configs/bashrc

--- a/configs/bashrc
+++ b/configs/bashrc
@@ -1,4 +1,4 @@
-source ~/.local/share/omakub/defaults/bash/rc
+source "$OMAKUB_PATH/defaults/bash/rc"
 
 # Editor used by CLI
 export EDITOR="nvim"

--- a/defaults/bash/rc
+++ b/defaults/bash/rc
@@ -1,4 +1,4 @@
-source ~/.local/share/omakub/defaults/bash/shell
-source ~/.local/share/omakub/defaults/bash/aliases
-source ~/.local/share/omakub/defaults/bash/prompt
-source ~/.local/share/omakub/defaults/bash/init
+source "$OMAKUB_PATH/defaults/bash/shell"
+source "$OMAKUB_PATH/defaults/bash/aliases"
+source "$OMAKUB_PATH/defaults/bash/prompt"
+source "$OMAKUB_PATH/defaults/bash/init"

--- a/defaults/bash/shell
+++ b/defaults/bash/shell
@@ -11,4 +11,7 @@ source /usr/share/bash-completion/bash_completion
 export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omakub/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
 set +h
 
-export OMAKUB_PATH="/home/$USER/.local/share/omakub"
+# Set OMAKUB_PATH if it not already set
+if [ -z "$OMAKUB_PATH" ]; then
+  export OMAKUB_PATH="/home/$USER/.local/share/omakub"
+fi

--- a/prompts/avatar.sh
+++ b/prompts/avatar.sh
@@ -1,0 +1,31 @@
+force_color_prompt=yes
+color_prompt=yes
+
+RED="$(tput setaf 1)"
+GREEN="$(tput setaf 2)"
+YELLOW="$(tput setaf 3)"
+BLUE="$(tput setaf 4)"
+MAGENTA="$(tput setaf 5)"
+CYAN="$(tput setaf 6)"
+WHITE="$(tput setaf 7)"
+GRAY="$(tput setaf 8)"
+BOLD="$(tput bold)"
+UNDERLINE="$(tput sgr 0 1)"
+INVERT="$(tput sgr 1 0)"
+NOCOLOR="$(tput sgr0)"
+
+# Symbols
+PROMPT_SYMBOL="❯"
+PROMPT_CLEAN_SYMBOL="☀ "
+PROMPT_DIRTY_SYMBOL="☂ "
+PROMPT_VENV_SYMBOL="☁ "
+
+case $(id -u) in
+	0) USER_COLOR="$RED" ;;
+	*) USER_COLOR="$GREEN" ;;
+esac
+
+PROMPT_LINE="\`if [ \$? = 0 ]; then echo \[\$CYAN\]; else echo \[\$RED\]; fi\`\$PROMPT_SYMBOL\[\$NOCOLOR\] "
+
+PS1="\[\e]0;\w\a\]$PROMPT_LINE"
+PS1="\[\e]0;\w\a\]$PS1"

--- a/prompts/avatar.sh
+++ b/prompts/avatar.sh
@@ -1,6 +1,7 @@
 force_color_prompt=yes
 color_prompt=yes
 
+# Colors
 RED="$(tput setaf 1)"
 GREEN="$(tput setaf 2)"
 YELLOW="$(tput setaf 3)"
@@ -16,16 +17,18 @@ NOCOLOR="$(tput sgr0)"
 
 # Symbols
 PROMPT_SYMBOL="❯"
-PROMPT_CLEAN_SYMBOL="☀ "
-PROMPT_DIRTY_SYMBOL="☂ "
-PROMPT_VENV_SYMBOL="☁ "
 
-case $(id -u) in
-	0) USER_COLOR="$RED" ;;
-	*) USER_COLOR="$GREEN" ;;
-esac
+# If the last subprocess exited with an error, show red colored
+PROMPT="\`if [ \$? = 0 ]; then echo \[\$BLUE\]; else echo \[\$RED\]; fi\`\$PROMPT_SYMBOL\[\$NOCOLOR\]"
 
-PROMPT_LINE="\`if [ \$? = 0 ]; then echo \[\$CYAN\]; else echo \[\$RED\]; fi\`\$PROMPT_SYMBOL\[\$NOCOLOR\] "
+# Support for Git
+export GIT_PS1_SHOWDIRTYSTATE=1
+PROMPT="\[\$YELLOW\]\$(__git_ps1)\[\$NOCOLOR\] $PROMPT"
 
-PS1="\[\e]0;\w\a\]$PROMPT_LINE"
-PS1="\[\e]0;\w\a\]$PS1"
+# Include workspace
+export PROMPT_DIRTRIM=2
+PROMPT="\[\$CYAN\]\w\[\$NOCOLOR\]$PROMPT"
+
+# Set PS1
+PS1="$PROMPT "
+PS1="\[\e]0;\u@\h\a\]$PS1"

--- a/prompts/default.sh
+++ b/prompts/default.sh
@@ -1,0 +1,5 @@
+force_color_prompt=yes
+color_prompt=yes
+
+PS1=$'\uf0a9 '
+PS1="\[\e]0;\w\a\]$PS1"


### PR DESCRIPTION
Hi @dhh 

In this PR I've added a prompts directory similar to fonts and themes. This will allow a user to change to different kinds of prompts.

I don't suggest Omakub should ship with a ton of prompts, but perhaps a couple of standard ones, the default you have, something that looks like Pure, or my own "Avatar"-style and perhaps even a Powerline.

Additionally, I've also made some changes to that Omakub uses `$OMAKUB_PATH` throughout the code, this allowed me to develop and enable a local version of Omakub next to the one installed in `~/.local/share/omakub`.

Last thoughts, it might make sense to rename `OMAKUB_PATH` to `OMAKUB_HOME` - while this is non essential, it does seem like `_HOME` suffix is more consistent with more libraries in my experiences.

For your convenience I've included a screenshot.

![omakub-prompt](https://github.com/basecamp/omakub/assets/5760821/a83ad780-e84a-4cfe-ac36-665b6e17ce6d)

Lastly, thanks for creating this. Omakub has renewed my interest in a Linux based setup.