### PR TITLE
Disable the line number display in bat command

### DIFF
--- a/defaults/bash/aliases
+++ b/defaults/bash/aliases
@@ -15,7 +15,7 @@ alias n='nvim'
 alias g='git'
 alias d='docker'
 alias r='rails'
-alias bat='batcat'
+alias bat='batcat --style=plain'
 
 # Git
 alias gcm='git commit -m'


### PR DESCRIPTION
By default, batcat displays line numbers, which interferes with multi-line text selection for copying (the line numbers get included in the copied text).

I believe it's better to keep the default behavior the same as cat on line number.

If you think this change isn't reasonable, feel free to just close the request.