### PR TITLE
Add php install/uninstall script

### DIFF
--- a/install/php.sh
+++ b/install/php.sh
@@ -1,0 +1,18 @@
+# install php with basic extensions
+sudo add-apt-repository -y ppa:ondrej/php
+sudo apt -y install php8.3 php8.3-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
+
+# install composer, the PHP package manager
+EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]
+then
+    >&2 echo 'ERROR: Invalid installer checksum'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
+rm composer-setup.php

--- a/uninstall/php.sh
+++ b/uninstall/php.sh
@@ -1,0 +1,4 @@
+sudo apt -y purge "php8.3*"
+sudo add-apt-repository -y --remove ppa:ondrej/php
+
+sudo rm /usr/local/bin/composer


### PR DESCRIPTION
Fixes #73 

- install PHP using apt, with some common extensions (e.g. all 3 main db drivers)
- install composer (package manager)
- ~[RFC: bonus] install the [symfony binary](https://github.com/symfony-cli/symfony-cli)~
- uninstall script following [uninstall codestyle](https://github.com/basecamp/omakub/commit/b42654f70e1c90f02ef001a43680bb2d560ad63b)

According to Laravel docs, the initial setup has all tools included (namely the `artisan` console). I'm not Laravel dev so I can't guarantee it's sufficient.