### PR TITLE
Add Ctrl-N keybinding to open new Alacritty window

### DIFF
--- a/defaults/alacritty.toml
+++ b/defaults/alacritty.toml
@@ -12,5 +12,6 @@ opacity = 0.97
 
 [keyboard]
 bindings = [
-{ key = "F11", action = "ToggleFullscreen" }
+{ key = "F11", action = "ToggleFullscreen" },
+{ key = "N", mods = "Control|Shift", action = "CreateNewWindow" }
 ]


### PR DESCRIPTION
When using a multi-monitor setup, multiple terminal windows can be desirable.  This PR adds an Alacritty keybinding to allow pressing Ctrl-N to open a new Alactritty window.