### PR TITLE
Add Gear Lever

### DIFF
--- a/install/optional/app-gearlever.sh
+++ b/install/optional/app-gearlever.sh
@@ -1,0 +1,1 @@
+flatpak install flathub it.mijorus.gearlever


### PR DESCRIPTION
An utility to manage AppImages with ease! Gear lever will organize and manage AppImage files for you, generate desktop entries and app metadata, update apps in-place or keep multiple versions side-by-side.

Dependent on Flatpak support.