### PR TITLE
enable ufw and turn of iptables for docker

### DIFF
--- a/install/terminal/docker.sh
+++ b/install/terminal/docker.sh
@@ -12,4 +12,4 @@ sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin d
 sudo usermod -aG docker ${USER}
 
 # Limit log size to avoid running out of disk
-echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json
+echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5", "iptables":false}}' | sudo tee /etc/docker/daemon.json

--- a/install/ufw.sh
+++ b/install/ufw.sh
@@ -1,0 +1,2 @@
+sudo ufw enable
+sudo ufw show verbose

--- a/migrations/1724276595.sh
+++ b/migrations/1724276595.sh
@@ -1,0 +1,4 @@
+echo "Hardening docker..."
+echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5", "iptables":false}}' | sudo tee /etc/docker/daemon.json
+echo "Enabling ufw firewall"
+source $OMAKUB_PATH/install/ufw.sh


### PR DESCRIPTION
Enabling UFW will block all incoming traffic by default and that's a good secure default. @dhh I added a file in the install folder, but this is just turning it on since it is installed by default. Is there a better location for this?
Addtionally, by default, docker exposes the ports on the local network and it can lead to security issues. Disabling the iptables rules docker appends prevents this while still having everything accessible on the host