### PR TITLE
eza: spacing after icon

### DIFF
--- a/defaults/bash/shell
+++ b/defaults/bash/shell
@@ -12,3 +12,6 @@ export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omakub/bin:/usr/local/sbi
 set +h
 
 export OMAKUB_PATH="/home/$USER/.local/share/omakub"
+
+# Specifies the number of spaces to print between an icon and its file name.
+export EZA_ICON_SPACING=2


### PR DESCRIPTION
This makes eza with icons looks a bit better.

Before:
![image](https://github.com/basecamp/omakub/assets/10061147/5692ab80-5051-4d3a-9b03-e0d3a0f2f8ac)

After:
![image](https://github.com/basecamp/omakub/assets/10061147/62898a27-1976-47a0-925d-3012a88c5d45)
