### PR TITLE
added command in app-neovim file to disable plug in notifications

### DIFF
--- a/install/app-neovim.sh
+++ b/install/app-neovim.sh
@@ -12,3 +12,7 @@ if [ ! -d "$HOME/.config/nvim" ]; then
 	# Disable plugin update notifications
 	sed -i '/enabled = true,/a\    notify = false,' ~/.config/nvim/lua/config/lazy.lua
 fi
+
+if ! grep -q "notify" ~/.config/nvim/lua/config/lazy.lua; then
+	sed -i '/enabled = true,/a\    notify = false,' ~/.config/nvim/lua/config/lazy.lua
+fi

--- a/install/app-neovim.sh
+++ b/install/app-neovim.sh
@@ -8,4 +8,7 @@ if [ ! -d "$HOME/.config/nvim" ]; then
 
 	# Enable default extras
 	cp ~/.local/share/omakub/configs/neovim/lazyvim.json ~/.config/nvim/lazyvim.json
+
+	# Disable plugin update notifications
+	sed -i '/enabled = true,/a\    notify = false,' ~/.config/nvim/lua/config/lazy.lua
 fi


### PR DESCRIPTION
This will disable notification after installing lazyvim.
It adds one config to lazy.lua, and didn't make that line to be executed every time because every time will add that sam config.
So I would say the only problem can be that with update command wont be executed, I assume it should be copied and pasted do terminal manually.