### PR TITLE
Remote auth prop when installing flatpak repo

### DIFF
--- a/install/optional/app-flatpak.sh
+++ b/install/optional/app-flatpak.sh
@@ -1,3 +1,3 @@
 sudo apt install -y flatpak
 sudo apt install -y gnome-software-plugin-flatpak
-flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
Added `sudo` to sidestep auth prompt per comment:
https://github.com/basecamp/omakub/pull/102#issuecomment-2165132621