### PR TITLE
fix: disable lazyvim plugin update notify

### DIFF
--- a/install/app-neovim.sh
+++ b/install/app-neovim.sh
@@ -2,6 +2,8 @@ sudo apt install -y neovim
 
 if [ ! -d "$HOME/.config/nvim" ]; then
 	git clone https://github.com/LazyVim/starter ~/.config/nvim
+	# Disable update notification popup in starter config
+	sed -i 's/checker = { enabled = true }/checker = { enabled = true, notify = false }/g' ~/.config/nvim/lua/config/lazy.lua
 	mkdir -p ~/.config/nvim/plugin/after
 	cp ~/.local/share/omakub/configs/neovim/transparency.lua ~/.config/nvim/plugin/after/
 	cp ~/.local/share/omakub/themes/neovim/tokyo-night.lua ~/.config/nvim/lua/plugins/theme.lua


### PR DESCRIPTION
Changes the default setting from the starter config - see https://www.lazyvim.org/configuration/lazy.nvim for details

Closes #115