### PR TITLE
Set Chrome default browser on install

### DIFF
--- a/install/app-chrome.sh
+++ b/install/app-chrome.sh
@@ -2,4 +2,5 @@ cd /tmp
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 sudo apt install -y ./google-chrome-stable_current_amd64.deb
 rm google-chrome-stable_current_amd64.deb
+xdg-settings set default-web-browser google-chrome.desktop
 cd -


### PR DESCRIPTION
Triggering google search via ULaucher  opens Firefox which is default.
Do we want to make Chrome default browser?

![Screenshot from 2024-06-13 23-40-21](https://github.com/basecamp/omakub/assets/1857476/ae1552bc-dfb0-42ea-adc6-a689f841cc5a)
