### PR TITLE
Install hex package manager after install Elixir

### DIFF
--- a/install/select-dev-env.sh
+++ b/install/select-dev-env.sh
@@ -23,6 +23,7 @@ for language in $languages; do
 	Elixir)
 		mise use --global erlang@latest
 		mise use --global elixir@latest
+		mise x elixir -- mix local.hex --force
 		;;
 	PHP)
 		sudo add-apt-repository -y ppa:ondrej/php


### PR DESCRIPTION
After the conversation in the #121 we decided to also install [hex](https://hex.pm) package manager after installing Elixir. 