### PR TITLE
Add uninstall chrome

### DIFF
--- a/uninstall/app-chrome.sh
+++ b/uninstall/app-chrome.sh
@@ -1,0 +1,1 @@
+sudo apt remove -y google-chrome-stable


### PR DESCRIPTION
Sometimes the chrome browser doesn't run after
omakub script finishes.

To solve this problem it's necessary uninstall
chrome, install it again, and, finally,
restart ubuntu.