### PR TITLE
Fix neovim install

### DIFF
--- a/install/app-neovim.sh
+++ b/install/app-neovim.sh
@@ -2,6 +2,8 @@ cd /tmp
 wget -O nvim.tar.gz "https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz"
 tar -xf nvim.tar.gz
 sudo install nvim-linux64/bin/nvim /usr/local/bin/nvim
+sudo cp -R nvim-linux64/lib /usr/local/
+sudo cp -R nvim-linux64/share /usr/local/
 rm -rf nvim-linux64 nvim.tar.gz
 cd -
 


### PR DESCRIPTION
The lib and share folder should also be copied. The binary is not enough.

Without this PR I get this error when starting neovim after a fresh installation:

![image](https://github.com/basecamp/omakub/assets/10061147/39143c3b-d5b5-44b9-946a-73ebd97bd819)
