### PR TITLE
Generalizes launching a new instance of dock applications with Shift + Alt + 1/2/..

### DIFF
--- a/install/desktop/set-dock.sh
+++ b/install/desktop/set-dock.sh
@@ -47,3 +47,6 @@ favorites_list="[${favorites_list%,}]"
 
 # Set the favorite apps
 gsettings set org.gnome.shell favorite-apps "$favorites_list"
+
+# Define the behavior of the app-hotkey binding
+gsettings set org.gnome.shell.extensions.dash-to-dock click-action 'focus-minimize-or-previews'

--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -17,16 +17,21 @@ gsettings set org.gnome.desktop.wm.keybindings toggle-fullscreen "['<Shift>F11']
 gsettings set org.gnome.mutter dynamic-workspaces false
 gsettings set org.gnome.desktop.wm.preferences num-workspaces 6
 
+set_per_digit() {
+  # shellcheck disable=SC2068
+  # Replace every "#" with the value of $n
+  for n in {1..9}; do gsettings set ${@//\#/$n}; done
+}
+
 # Use alt for pinned apps
-gsettings set org.gnome.shell.keybindings switch-to-application-1 "['<Alt>1']"
-gsettings set org.gnome.shell.keybindings switch-to-application-2 "['<Alt>2']"
-gsettings set org.gnome.shell.keybindings switch-to-application-3 "['<Alt>3']"
-gsettings set org.gnome.shell.keybindings switch-to-application-4 "['<Alt>4']"
-gsettings set org.gnome.shell.keybindings switch-to-application-5 "['<Alt>5']"
-gsettings set org.gnome.shell.keybindings switch-to-application-6 "['<Alt>6']"
-gsettings set org.gnome.shell.keybindings switch-to-application-7 "['<Alt>7']"
-gsettings set org.gnome.shell.keybindings switch-to-application-8 "['<Alt>8']"
-gsettings set org.gnome.shell.keybindings switch-to-application-9 "['<Alt>9']"
+#
+# Either show or launch the n-th dock application
+set_per_digit org.gnome.shell.extensions.dash-to-dock app-hotkey-# "['<Alt>#']"
+# Launch a new n-th dock application
+set_per_digit org.gnome.shell.extensions.dash-to-dock app-ctrl-hotkey-# "['<Ctrl><Alt>#']"
+set_per_digit org.gnome.shell.extensions.dash-to-dock app-shift-hotkey-# "['<Shift><Alt>#']"
+# Prevent the default <Super># bindings of switch-to-application from colliding with switch-to-workspace
+set_per_digit org.gnome.shell.keybindings switch-to-application-# "[]"
 
 # Use super for workspaces
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-1 "['<Super>1']"
@@ -37,7 +42,7 @@ gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
 
 # Reserve slots for custom keybindings
-gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']"
+gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/']"
 
 # Set ulauncher to Super+Space
 gsettings set org.gnome.desktop.wm.keybindings switch-input-source "@as []"
@@ -49,13 +54,3 @@ gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/or
 gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/ name 'Flameshot'
 gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/ command 'sh -c -- "flameshot gui"'
 gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/ binding '<Control>Print'
-
-# Start a new alacritty window (rather than just switch to the already open one)
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/ name 'alacritty'
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/ command 'alacritty'
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/ binding '<Shift><Alt>2'
-
-# Start a new Chrome window (rather than just switch to the already open one)
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/ name 'new chrome'
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/ command 'google-chrome'
-gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/ binding '<Shift><Alt>1'

--- a/migrations/1722293148.sh
+++ b/migrations/1722293148.sh
@@ -1,0 +1,15 @@
+echo "Running upgrade migration..."
+
+# Reset specific key bindings for launching new Alacrity and Chrome instances.
+# This functionality is now handled by the generic <Shift><Alt>NUMBER combination,
+# where the NUMBER is the position of the pinned application on the dock.
+gsettings reset-recursively org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/
+gsettings reset-recursively org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/
+
+# Change dock icon click action and app-hotkey bindings behavior to launch
+# or focus (if minimized) or minimize (if active)
+# or show previews (if minimized and there are multiple running instances of the application).
+gsettings set org.gnome.shell.extensions.dash-to-dock click-action 'focus-minimize-or-previews'
+
+# Apply generic app-hotkey bindings.
+source "$OMAKUB_PATH/install/desktop/set-gnome-hotkeys.sh"


### PR DESCRIPTION
Alacrity and Chrome get special status for the ability to launch a new instance. I believe the Dock platform should provide equal facilities to all residents. 🙂

Besides, the custom shortcuts are tied to the position and the application beyond the Dock's influence. The Alt+# and Shift+Alt+# friendship will be forever broken if I install, say, Brave in second spot.

---

Also changes the behaviour of the Alt + 1/2/3 shortcuts to launch/show and minimize applications with the same keystroke.