### PR TITLE
Add the path set at the OS level

### DIFF
--- a/defaults/bash/shell
+++ b/defaults/bash/shell
@@ -8,7 +8,7 @@ HISTFILESIZE="${HISTSIZE}"
 source /usr/share/bash-completion/bash_completion
 
 # Set complete path
-export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omakub/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omakub/bin:$PATH"
 set +h
 
 export OMAKUB_PATH="/home/$USER/.local/share/omakub"


### PR DESCRIPTION
Omakub does not allow any changes to the `PATH` environment variable via system-wide profile scripts (e.g. scripts placed in `/etc/profile.d`).

The `$PATH` env var was placed at the end in order to preserve the precedence of the `./bin`, `~/.local/bin` and `~/.local/share/omakub/bin` locations. The rest of the PATH is already set system-wide:

```
$ cat /etc/environment
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
```
