### PR TITLE
Add newline config to vscode settings

### DIFF
--- a/configs/vscode.json
+++ b/configs/vscode.json
@@ -22,5 +22,7 @@
   "explorer.confirmDelete": false,
   "extensions.ignoreRecommendations": true,
   "workbench.colorTheme": "Tokyo Night",
-  "window.titleBarStyle": "custom"
+  "window.titleBarStyle": "custom",
+  "files.insertFinalNewline": true,
+  "editor.scrollBeyondLastLine": false
 }


### PR DESCRIPTION
Adding these to the vscode settings,

```
"files.insertFinalNewline": true,
"editor.scrollBeyondLastLine": false
```