### PR TITLE
Enable command hashing

### DIFF
--- a/defaults/bash/shell
+++ b/defaults/bash/shell
@@ -9,6 +9,5 @@ source /usr/share/bash-completion/bash_completion
 
 # Set complete path
 export PATH="./bin:$HOME/.local/bin:$HOME/.local/share/omakub/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
-set +h
 
 export OMAKUB_PATH="/home/$USER/.local/share/omakub"


### PR DESCRIPTION
`set +h` disables command hashing.

Tools like [nvm](https://github.com/nvm-sh/nvm/blob/master/nvm.sh) are using the `hash` command and this will cause a hint to be displayed everytime the `~/.bashrc` file is executed:

```
bash: hash: hashing disabled
```

Removing `set +h` enables command hashing and avoids the hint.