### PR TITLE
Zellij: copy to clipboard on mouse select

### DIFF
--- a/configs/zellij.kdl
+++ b/configs/zellij.kdl
@@ -1,3 +1,4 @@
 theme "tokyo-night"
 default_layout "compact"
 on_force_close "quit"
+copy_on_select true


### PR DESCRIPTION
If we find this useful, enables copy on mouse select in terminal