### PR TITLE
Add installer and uninstaller for CopyQ Clipboard Manager

### DIFF
--- a/help/hotkeys.md
+++ b/help/hotkeys.md
@@ -93,3 +93,9 @@ The joy of Linux flows from the keyboard. Training yourself to navigate and comm
 | CapsLock M X | 🎉 | xellebrate |
 | CapsLock M 1 | 💯 | 100%       |
 | CapsLock M T | 🥂 | toast      |
+
+## Clipboard history
+
+| Hotkey            | Function               |
+| ----------------- | ---------------------- |
+| Super + Shift + V | Show clipboard history |

--- a/install/app-copyq.sh
+++ b/install/app-copyq.sh
@@ -1,0 +1,31 @@
+sudo add-apt-repository -y ppa:hluk/copyq
+sudo apt update -y
+sudo apt install -y copyq
+
+# start copyq to create initial config files
+copyq --start-server
+
+while [ ! -d "$HOME/.config/copyq" ]; do
+	echo "Waiting for copyq configuration path to exist..."
+	sleep 1
+done
+
+copyq exit >/dev/null
+
+COPYQ_COMMAND_SIZE=$(grep '^size=' ~/.config/copyq/copyq-commands.ini | cut -d= -f 2)
+NEW_COPYQ_COMMAND_SIZE=$(($COPYQ_COMMAND_SIZE + 1))
+
+# Ignore copying from windows that contain the title "Password"
+cat <<EOF >>~/.config/copyq/copyq-commands.ini
+$NEW_COPYQ_COMMAND_SIZE\Automatic=true
+$NEW_COPYQ_COMMAND_SIZE\Command=copyq ignore
+$NEW_COPYQ_COMMAND_SIZE\Icon=*
+$NEW_COPYQ_COMMAND_SIZE\Name=Ignore *\"Password\"* window
+$NEW_COPYQ_COMMAND_SIZE\Remove=true
+$NEW_COPYQ_COMMAND_SIZE\Window=Password
+EOF
+
+sed -i '/^size=/d' ~/.config/copyq/copyq-commands.ini
+echo "size=$NEW_COPYQ_COMMAND_SIZE" >>~/.config/copyq/copyq-commands.ini
+
+copyq --start-server

--- a/uninstall/app-copyq.sh
+++ b/uninstall/app-copyq.sh
@@ -1,0 +1,4 @@
+sudo add-apt-repository -r -y ppa:hluk/copyq
+sudo apt remove -y copyq
+
+rm -rf ~/.config/copyq


### PR DESCRIPTION
CopyQ is a clipboard history manager.

Since 1Password is also installed by omakub, the installer will configure CopyQ to ignore passwords copied from 1Password so that information isn't leaked on screen later (e.g. sharing your screen).

The clipboard history can be accessed by default with Super+Shift+V

Based this on a discussion with @AlexZeitler in Campfire