### PR TITLE
Extension: install weekday start extension

### DIFF
--- a/install/set-gnome-extensions.sh
+++ b/install/set-gnome-extensions.sh
@@ -16,6 +16,7 @@ gext install just-perfection-desktop@just-perfection
 gext install blur-my-shell@aunetx
 gext install space-bar@luchrioh
 gext install undecorate@sun.wxg@gmail.com
+gext install weeks-start-on-monday@extensions.gnome-shell.fifi.org
 
 # Compile gsettings schemas in order to be able to set them
 sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/

--- a/install/set-gnome-extensions.sh
+++ b/install/set-gnome-extensions.sh
@@ -65,5 +65,8 @@ gsettings set org.gnome.shell.extensions.space-bar.shortcuts open-menu "@as []"
 # Configure tweaks
 gsettings set org.gnome.mutter center-new-windows true
 
+# Configure weekday extension
+dconf write /org/gnome/shell/extensions/weeks-start-on-monday/start-day 0
+
 # Set Cascadia Mono as the default monospace font
 gsettings set org.gnome.desktop.interface monospace-font-name 'CaskaydiaMono Nerd Font 10'


### PR DESCRIPTION
[This extension](https://extensions.gnome.org/extension/1720/weeks-start-on-monday-again/) allows to select the day with which the week starts

![image](https://github.com/basecamp/omakub/assets/287480/967d47bf-3579-4a1a-83ab-160917ee7b1a)
