### PR TITLE
Replace Pinta installation from Snap to Flatpak

### DIFF
--- a/install/app-pinta.sh
+++ b/install/app-pinta.sh
@@ -1,2 +1,1 @@
-# FIXME: Get this out of snap
-sudo snap install pinta
+sudo flatpak install flathub com.github.PintaProject.Pinta

--- a/uninstall/app-pinta.sh
+++ b/uninstall/app-pinta.sh
@@ -1,1 +1,1 @@
-sudo snap remove pinta
+sudo flatpak uninstall com.github.PintaProject.Pinta


### PR DESCRIPTION
Via https://flathub.org/apps/com.github.PintaProject.Pinta

> [!NOTE]  
> Needs testing. Hopefully, the priority is right and `flatpak` installs before we use it in other app scripts.