### PR TITLE
Add `gst` alias for `git status`

### DIFF
--- a/defaults/bash/aliases
+++ b/defaults/bash/aliases
@@ -24,6 +24,7 @@ alias lzd='lazydocker'
 alias gcm='git commit -m'
 alias gcam='git commit -a -m'
 alias gcad='git commit -a --amend'
+alias gst='git status'
 
 # Compression
 compress() { tar -czf "${1%/}.tar.gz" "${1%/}"; }


### PR DESCRIPTION
Inspired by the alias defined by `oh-my-zsh`: https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/git/git.plugin.zsh

Since knowing the current state of a git repo is quite useful, maybe it could be nice to add it to the default aliases!