### PR TITLE
feat: docker startup on boot + user docker in current shell

### DIFF
--- a/install/docker.sh
+++ b/install/docker.sh
@@ -2,14 +2,24 @@
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo wget -qO /etc/apt/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg
 sudo chmod a+r /etc/apt/keyrings/docker.asc
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 sudo apt update
 
 # Install Docker engine and standard plugins
 sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras
 
+# create docker group
+sudo groupadd docker
+
 # Give this user privileged Docker access
 sudo usermod -aG docker ${USER}
 
+# change group ID to docker to activate change in current shell
+newgrp docker
+
+# configure docker to start on boot (& right now) with systemd
+sudo systemctl enable --now docker.service
+sudo systemctl enable --now containerd.service
+
 # Use local logging driver - it's more efficient and uses compression by default.
-echo '{"log-driver":"local","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json > /dev/null
+echo '{"log-driver":"local","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json >/dev/null


### PR DESCRIPTION
Allow user to use docker in current shell without reloading shell & systemd startup docker on boot as per Docker's post-installation steps.

https://docs.docker.com/engine/install/linux-postinstall/