### PR TITLE
Fix Alacritty (and others) fonts

### DIFF
--- a/fonts/alacritty/CaskaydiaMono.toml
+++ b/fonts/alacritty/CaskaydiaMono.toml
@@ -1,4 +1,4 @@
 [font]
-normal = { family = "CaskaydiaMono Nerd Font", style = "Regular" }
-bold = { family = "CaskaydiaMono Nerd Font", style = "Bold" }
-italic = { family = "CaskaydiaMono Nerd Font", style = "Italic" }
+normal = { family = "CaskaydiaMono Nerd Font Mono", style = "Regular" }
+bold = { family = "CaskaydiaMono Nerd Font Mono", style = "Bold" }
+italic = { family = "CaskaydiaMono Nerd Font Mono", style = "Italic" }

--- a/fonts/alacritty/FiraMono.toml
+++ b/fonts/alacritty/FiraMono.toml
@@ -1,4 +1,4 @@
 [font]
-normal = { family = "FiraMono Nerd Font", style = "Regular" }
-bold = { family = "FiraMono Nerd Font", style = "Bold" }
-italic = { family = "FiraMono Nerd Font", style = "Italic" }
+normal = { family = "FiraMono Nerd Font Mono", style = "Regular" }
+bold = { family = "FiraMono Nerd Font Mono", style = "Bold" }
+italic = { family = "FiraMono Nerd Font Mono", style = "Italic" }

--- a/fonts/alacritty/JetBrainsMono.toml
+++ b/fonts/alacritty/JetBrainsMono.toml
@@ -1,4 +1,4 @@
 [font]
-normal = { family = "JetBrainsMono Nerd Font", style = "Regular" }
-bold = { family = "JetBrainsMono Nerd Font", style = "Bold" }
-italic = { family = "JetBrainsMono Nerd Font", style = "Italic" }
+normal = { family = "JetBrainsMono Nerd Font Mono", style = "Regular" }
+bold = { family = "JetBrainsMono Nerd Font Mono", style = "Bold" }
+italic = { family = "JetBrainsMono Nerd Font Mono", style = "Italic" }

--- a/fonts/alacritty/MesloLGS.toml
+++ b/fonts/alacritty/MesloLGS.toml
@@ -1,4 +1,4 @@
 [font]
-normal = { family = "MesloLGLDZ Nerd Font", style = "Regular" }
-bold = { family = "MesloLGLDZ Nerd Font", style = "Bold" }
-italic = { family = "MesloLGLDZ Nerd Font", style = "Italic" }
+normal = { family = "MesloLGLDZ Nerd Font Mono", style = "Regular" }
+bold = { family = "MesloLGLDZ Nerd Font Mono", style = "Bold" }
+italic = { family = "MesloLGLDZ Nerd Font Mono", style = "Italic" }


### PR DESCRIPTION
I believe this is what should be used instead. It fixes the displaying of some unicode symbols. 

Some examples below: 

New: Using JetBrainsMono Nerd Font Mono
![image](https://github.com/basecamp/omakub/assets/103049321/84ac202c-b730-472c-be5d-2c484d1786ea)

Old: Using JetBrainsMono Nerd Font
![image](https://github.com/basecamp/omakub/assets/103049321/c37613c3-6a92-4a32-8291-563b2920cfd1)
