### PR TITLE
Use default browser to open omakub manual

### DIFF
--- a/bin/omakub-sub/manual.sh
+++ b/bin/omakub-sub/manual.sh
@@ -1,2 +1,2 @@
-google-chrome "https://manual.omakub.org" >/dev/null
+xdg-open "https://manual.omakub.org" >/dev/null
 source $OMAKUB_PATH/bin/omakub-sub/menu.sh


### PR DESCRIPTION
Users may have changed their default browser from Chrome to Brave or Firefox (or another browser), so we can leverage `xdg-open` to open the omakub manual using their default browser.