### PR TITLE
Restore `set -e` line in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 # Exit immediately if a command exits with a non-zero status
-# set -e
+set -e
 
 # Desktop software and tweaks will only be installed if we're running Gnome
 RUNNING_GNOME=$([[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] && echo true || echo false)


### PR DESCRIPTION
Noticed this was commented out in a recent [commit](https://github.com/basecamp/omakub/commit/a01ef804d6c8a862477db4c9e04e765ff91e2a1c), which may have been accidental?

If it was intentional, should we remove it and the line above it?