### PR TITLE
Doom emacs

### DIFF
--- a/bin/omakub-sub/install.sh
+++ b/bin/omakub-sub/install.sh
@@ -3,6 +3,7 @@ CHOICES=(
 	"Dev Database  Install development database in Docker"
 	"1password     Manage your passwords securely across devices"
 	"Brave         Chrome-based browser with built-in ad blocking"
+	"Doom Emacs    Emacs framework with curated list of packages"
 	"Dropbox       Sync files across computers with ease"
 	"OBS Studio    Record screencasts with inputs from both display + webcam"
 	"Audacity      Record and edit audio"

--- a/install/desktop/optional/app-doom-emacs.sh
+++ b/install/desktop/optional/app-doom-emacs.sh
@@ -1,0 +1,5 @@
+sudo apt update -y
+sudo apt upgrade -y
+sudo apt install -y emacs cmake libtool-bin
+git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
+~/.config/emacs/bin/doom install

--- a/install/desktop/optional/app-doom-emacs.sh
+++ b/install/desktop/optional/app-doom-emacs.sh
@@ -1,5 +1,3 @@
-sudo apt update -y
-sudo apt upgrade -y
-sudo apt install -y emacs cmake libtool-bin
+sudo apt install -y emacs
 git clone --depth 1 https://github.com/doomemacs/doomemacs ~/.config/emacs
 ~/.config/emacs/bin/doom install

--- a/uninstall/app-doom-emacs.sh
+++ b/uninstall/app-doom-emacs.sh
@@ -1,0 +1,3 @@
+sudo apt remove --purge -y emacs cmake libtool-bin
+sudo rm -rf ~/.config/emacs
+sudo rm -rf ~/.config/doom

--- a/uninstall/app-doom-emacs.sh
+++ b/uninstall/app-doom-emacs.sh
@@ -1,3 +1,4 @@
-sudo apt remove --purge -y emacs cmake libtool-bin
+sudo apt remove --purge -y emacs emacs-gtk
 sudo rm -rf ~/.config/emacs
+sudo rm -rf ~/.emacs.d
 sudo rm -rf ~/.config/doom


### PR DESCRIPTION
Add option to install Emacs and Doom Emacs 

Option to install [GNU Emacs](https://www.gnu.org/software/emacs/) and [Doom Emacs](https://github.com/doomemacs/doomemacs) 

**GNU Emacs:**
An extensible, customizable, [free/libre](https://www.gnu.org/philosophy/free-sw.html) text editor  — and more. At its core is an interpreter for Emacs Lisp, a dialect of the Lisp programming language with extensions to support text editing.

**Doom Emacs:**
Doom Emacs is a configuration framework for GNU Emacs tailored for Emacs bankruptcy veterans who want less framework in their frameworks, a modicum of stability (and reproducibility) from their package manager, and the performance of a hand rolled config (or better). It can be a foundation for your own config or a resource for Emacs enthusiasts to learn more about our favorite operating system.