### PR TITLE
feature: add auto light/dark theme switch

### DIFF
--- a/bin/dark-mode-switch.sh
+++ b/bin/dark-mode-switch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Function to execute when dark mode is enabled
+dark_mode_on() {
+	echo "Dark mode enabled, setting \"Tokyo Night\" theme"
+	export DESIRED_THEME="tokyo-night"
+	set_theme
+}
+
+# Function to execute when light mode is enabled
+light_mode_on() {
+	echo "Light mode enabled, setting \"Red Pine\" theme"
+	export DESIRED_THEME="rose-pine"
+	set_theme
+}
+
+set_theme() {
+	# Create a temporary gum function that returns the desired theme
+	function gum() {
+		if [[ $1 == "choose" ]]; then
+			echo "$DESIRED_THEME"
+		else
+			command gum "$@"
+		fi
+	}
+
+	# Run the script with the overridden gum function
+	( gum() { if [[ $1 == "choose" ]]; then echo "$DESIRED_THEME"; else command gum "$@"; fi; }; bash $OMAKUB_PATH/bin/omakub-sub/theme.sh )
+}
+
+
+check_mode() {
+    local mode=$(gsettings get org.gnome.desktop.interface color-scheme)
+    if [[ $mode == *"prefer-dark"* ]]; then
+        dark_mode_on
+    else
+        light_mode_on
+    fi
+}
+
+# Monitor changes in the settings
+while true; do
+    current_mode=$(gsettings get org.gnome.desktop.interface color-scheme)
+    if [ "$current_mode" != "$previous_mode" ]; then
+        previous_mode=$current_mode
+        check_mode
+    fi
+    sleep 1
+done

--- a/bin/dark-mode-switch.sh
+++ b/bin/dark-mode-switch.sh
@@ -9,7 +9,7 @@ dark_mode_on() {
 
 # Function to execute when light mode is enabled
 light_mode_on() {
-	echo "Light mode enabled, setting \"Red Pine\" theme"
+	echo "Light mode enabled, setting \"Rose Pine\" theme"
 	export DESIRED_THEME="rose-pine"
 	set_theme
 }

--- a/install/desktop/optional/app-auto-dark-mode.sh
+++ b/install/desktop/optional/app-auto-dark-mode.sh
@@ -1,0 +1,23 @@
+cat > /tmp/darkmode-monitor.service <<EOT
+[Unit]
+Description=Dark Mode Monitor
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=$OMAKUB_PATH/bin/dark-mode-switch.sh
+Restart=always
+User=$USER
+Environment=OMAKUB_PATH=$OMAKUB_PATH
+Environment=XDG_RUNTIME_DIR=/run/user/$(id -u)
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus
+
+[Install]
+WantedBy=default.target
+EOT
+
+sudo mv /tmp/darkmode-monitor.service /etc/systemd/system/darkmode-monitor.service
+
+sudo systemctl daemon-reload
+sudo systemctl enable darkmode-monitor.service
+sudo systemctl start darkmode-monitor.service

--- a/uninstall/app-auto-dark-mode.sh
+++ b/uninstall/app-auto-dark-mode.sh
@@ -1,0 +1,6 @@
+SERVICE_NAME=darkmode-monitor.service
+
+sudo systemctl stop $SERVICE_NAME
+sudo systemctl disable $SERVICE_NAME
+sudo rm /etc/systemd/system/$SERVICE_NAME
+sudo systemctl daemon-reload


### PR DESCRIPTION
This adds a script that watches the gsettings to detect light or dark mode, and creates a systemd service that runs it in the background. When a switch is detected, it triggers the corresponding theme change.

Fixes #200 

Possible issues (non blocking):

- you have to edit the file to configure the two themes. For now I defaulted to Tokyo Night / Rose Pine, open to feedback on where to store other settings.
- I only tested on wayland, and there is some part of specific in the script (I debugged some issues because of this)
- There is some error output in the service logs because the `source $OMAKUB_PATH/bin/omakub-sub/menu.sh` at the end of the `theme.sh` script crashes with my workaround for applying a theme without prompting "gum choose" . It's not an issue at all but might raise some eyebrows. I made #201 to do this in a cleaner way.

How to test this PR:

- checkout this branch on your local  omakub instance, or copy the files directly
- run `install/desktop/optional/app-auto-dark-mode.sh`
- try switching dark/light mode
- confirm the theme switch
- revert with the uninstall script and delete the files if needed to cleanup