### PR TITLE
Fix eza installation

### DIFF
--- a/install/terminal/apps-terminal.sh
+++ b/install/terminal/apps-terminal.sh
@@ -1,1 +1,9 @@
-sudo apt install -y fzf ripgrep bat eza zoxide plocate btop apache2-utils fd-find
+sudo apt install -y fzf ripgrep bat zoxide plocate btop apache2-utils fd-find
+
+# Install eza
+sudo mkdir -p /etc/apt/keyrings
+wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
+echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
+sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
+sudo apt update
+sudo apt install -y eza


### PR DESCRIPTION
Catched an error of `Unable to locate package eza`.

Fixed by implementing code from https://github.com/eza-community/eza/blob/main/INSTALL.md#debian-and-ubuntu
