### PR TITLE
Add TLDR CLI Support

### DIFF
--- a/install/terminal/apps-terminal.sh
+++ b/install/terminal/apps-terminal.sh
@@ -1,1 +1,1 @@
-sudo apt install -y fzf ripgrep bat eza zoxide plocate btop apache2-utils fd-find
+sudo apt install -y fzf ripgrep bat eza zoxide plocate btop apache2-utils fd-find tldr


### PR DESCRIPTION
The [tldr](https://tldr.sh) pages are a community effort to simplify the beloved [man pages](https://en.wikipedia.org/wiki/Man_page) with practical examples.

Experienced developers, be they on Linux or macOS, will learn the commands and arguments they use on the day-to-day off by heart, even maybe adding aliases to further optimise their use.

For new commands and commands that are not used regularly, it is useful and quite reasonable to use a tool, right there in the terminal, to quickly query the most common usages of said commands.

In my estimation this could be quite useful for developers on macOS switching to Omakub/Linux, as they learn and transition to doing more and more in their shell compared to through apps.

---

An example for me is tar - I don't use it regularly enough to remember it, so I just look it up:

![image](https://github.com/user-attachments/assets/e2da4403-0672-4ddd-aa6d-bdb4f0d5a4e5)


