### PR TITLE
Define env EDITOR var before starting Zellij

### DIFF
--- a/configs/bashrc
+++ b/configs/bashrc
@@ -1,5 +1,4 @@
 source ~/.local/share/omakub/defaults/bash/rc
 
 # Editor used by CLI
-export EDITOR="nvim"
 export SUDO_EDITOR="$EDITOR"

--- a/defaults/alacritty.toml
+++ b/defaults/alacritty.toml
@@ -1,5 +1,6 @@
 [env]
 TERM = "xterm-256color"
+EDITOR = "nvim"
 
 [shell]
 program = "zellij"

--- a/defaults/bash/aliases
+++ b/defaults/bash/aliases
@@ -14,6 +14,8 @@ alias ....='cd ../../..'
 
 # Tools
 alias n='nvim'
+alias vi='nvim'
+alias vim='nvim'
 alias g='git'
 alias d='docker'
 alias r='rails'


### PR DESCRIPTION
The command "vim" is not working.

Documentation:

"By default, Zellij looks for an editor defined in the EDITOR or VISUAL environment variables (in this order). Make sure one is set (eg. export EDITOR=/usr/bin/vim) before Zellij starts."