### PR TITLE
Update app-zellij.sh not to crash if `~/.config/zellij/themes` exists

### DIFF
--- a/install/terminal/app-zellij.sh
+++ b/install/terminal/app-zellij.sh
@@ -5,6 +5,8 @@ sudo install zellij /usr/local/bin
 rm zellij.tar.gz zellij
 cd -
 
-mkdir -p ~/.config/zellij/themes
+if [ ! -d "$HOME/.config/zellij/themes" ]; then
+  mkdir -p ~/.config/zellij/themes
+fi
 [ ! -f "$HOME/.config/zellij/config.kdl" ] && cp ~/.local/share/omakub/configs/zellij.kdl ~/.config/zellij/config.kdl
 cp ~/.local/share/omakub/themes/tokyo-night/zellij.kdl ~/.config/zellij/themes/tokyo-night.kdl


### PR DESCRIPTION
If the `.config/zellij/themes` exists omakub install fails.

This PR adds a check on the presence of `~/.config/zellij/themes` before attempting to create the folder