### PR TITLE
Add Flutter support

### DIFF
--- a/configs/neovim/lazyvim.json
+++ b/configs/neovim/lazyvim.json
@@ -1,4 +1,15 @@
 {
   "extras": [ "lazyvim.plugins.extras.lang.go" ],
-  "version": 6
+  "version": 6,
+  "plugins": [
+    {
+      "name": "akinsho/flutter-tools.nvim",
+      "lazy": false,
+      "dependencies": [
+        "nvim-lua/plenary.nvim",
+        "stevearc/dressing.nvim"
+      ],
+      "config": true
+    }
+  ]
 }

--- a/first_run_choices.sh
+++ b/first_run_choices.sh
@@ -2,7 +2,7 @@ OPTIONAL_APPS=("1password" "Spotify" "Zoom" "Dropbox")
 DEFAULT_OPTIONAL_APPS='1password,Spotify,Zoom'
 export OMAKUB_FIRST_RUN_OPTIONAL_APPS=$(gum choose "${OPTIONAL_APPS[@]}" --no-limit --selected $DEFAULT_OPTIONAL_APPS --height 7 --header "Select optional apps" | tr ' ' '-')
 
-AVAILABLE_LANGUAGES=("Ruby on Rails" "Node.js" "Go" "PHP" "Python" "Elixir" "Rust" "Java")
+AVAILABLE_LANGUAGES=("Ruby on Rails" "Node.js" "Go" "PHP" "Python" "Elixir" "Rust" "Java" "Flutter")
 SELECTED_LANGUAGES="Ruby on Rails","Node.js"
 export OMAKUB_FIRST_RUN_LANGUAGES=$(gum choose "${AVAILABLE_LANGUAGES[@]}" --no-limit --selected "$SELECTED_LANGUAGES" --height 10 --header "Select programming languages")
 

--- a/install/terminal/flutter.sh
+++ b/install/terminal/flutter.sh
@@ -6,14 +6,15 @@ sudo chown -R $USER:$USER /opt/flutter
 git config --global --add safe.directory /opt/flutter
 
 DIR=$(pwd)
-
 cd /opt/flutter
 git checkout stable
 ./bin/flutter --version
 
 cd $DIR
-
 echo "export PATH=\$PATH:/opt/flutter/bin" >> ~/.bashrc
 source ~/.bashrc
-
 flutter doctor
+
+# Install VS Code extensions
+code --install-extension dart-code.dart-code --force
+code --install-extension dart-code.flutter --force

--- a/install/terminal/flutter.sh
+++ b/install/terminal/flutter.sh
@@ -1,16 +1,9 @@
 #!/bin/
 
-sudo mkdir -p /opt/flutter
-sudo git clone https://github.com/flutter/flutter.git /opt/flutter
-sudo chown -R $USER:$USER /opt/flutter
-git config --global --add safe.directory /opt/flutter
+sudo snap install flutter --classic
+sudo snap alias flutter.dart dart
+flutter --version
 
-DIR=$(pwd)
-cd /opt/flutter
-git checkout stable
-./bin/flutter --version
-
-cd $DIR
 echo "export PATH=\$PATH:/opt/flutter/bin" >> ~/.bashrc
 source ~/.bashrc
 flutter doctor

--- a/install/terminal/flutter.sh
+++ b/install/terminal/flutter.sh
@@ -1,0 +1,19 @@
+#!/bin/
+
+sudo mkdir -p /opt/flutter
+sudo git clone https://github.com/flutter/flutter.git /opt/flutter
+sudo chown -R $USER:$USER /opt/flutter
+git config --global --add safe.directory /opt/flutter
+
+DIR=$(pwd)
+
+cd /opt/flutter
+git checkout stable
+./bin/flutter --version
+
+cd $DIR
+
+echo "export PATH=\$PATH:/opt/flutter/bin" >> ~/.bashrc
+source ~/.bashrc
+
+flutter doctor

--- a/install/terminal/flutter.sh
+++ b/install/terminal/flutter.sh
@@ -1,13 +1,9 @@
-#!/bin/
+#!/bin/bash
 
 sudo snap install flutter --classic
 sudo snap alias flutter.dart dart
 flutter --version
-
-echo "export PATH=\$PATH:/opt/flutter/bin" >> ~/.bashrc
-source ~/.bashrc
 flutter doctor
 
-# Install VS Code extensions
-code --install-extension dart-code.dart-code --force
+# Install VS Code extension
 code --install-extension dart-code.flutter --force

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -40,6 +40,9 @@ if [[ -n "$languages" ]]; then
 		Java)
 			mise use --global java@latest
 			;;
+		Flutter)
+			source ~/.local/share/omakub/install/terminal/flutter.sh
+			;;
 		esac
 	done
 fi

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -2,7 +2,7 @@
 if [[ -v OMAKUB_FIRST_RUN_LANGUAGES ]]; then
 	languages=$OMAKUB_FIRST_RUN_LANGUAGES
 else
-	AVAILABLE_LANGUAGES=("Ruby on Rails" "Node.js" "Go" "PHP" "Python" "Elixir" "Rust" "Java")
+	AVAILABLE_LANGUAGES=("Ruby on Rails" "Node.js" "Go" "PHP" "Python" "Elixir" "Rust" "Java" "Flutter")
 	languages=$(gum choose "${AVAILABLE_LANGUAGES[@]}" --no-limit --height 10 --header "Select programming languages")
 fi
 

--- a/uninstall/flutter.sh
+++ b/uninstall/flutter.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo rm -rf /opt/flutter
+
+sed -i '/\/opt\/flutter\/bin/d' ~/.bashrc
+
+source ~/.bashrc

--- a/uninstall/flutter.sh
+++ b/uninstall/flutter.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-sudo rm -rf /opt/flutter
-
+sudo snap remove flutter
 sed -i '/\/opt\/flutter\/bin/d' ~/.bashrc
-
 source ~/.bashrc
 
 # Uninstall VS Code extensions

--- a/uninstall/flutter.sh
+++ b/uninstall/flutter.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 sudo snap remove flutter
-sed -i '/\/opt\/flutter\/bin/d' ~/.bashrc
-source ~/.bashrc
 
-# Uninstall VS Code extensions
-code --uninstall-extension dart-code.dart-code
+# Uninstall VS Code extension
 code --uninstall-extension dart-code.flutter

--- a/uninstall/flutter.sh
+++ b/uninstall/flutter.sh
@@ -5,3 +5,7 @@ sudo rm -rf /opt/flutter
 sed -i '/\/opt\/flutter\/bin/d' ~/.bashrc
 
 source ~/.bashrc
+
+# Uninstall VS Code extensions
+code --uninstall-extension dart-code.dart-code
+code --uninstall-extension dart-code.flutter


### PR DESCRIPTION
## Motivation

Canonical mentioned that [Flutter is their default choice](https://ubuntu.com/blog/flutter-and-ubuntu-so-far) for new desktop and mobile apps, having re-designed and [re-built the Ubuntu installer with Flutter](https://canonical.com/blog/how-we-designed-the-new-ubuntu-desktop-installer). 

They list Flutter alongside Typescript and React in their Web Frontend Engineer [job requirements](https://canonical.com/careers/5150422).

As Flutter is technology that can build and deploy to the web, but also given it's ability to deploy to native platforms, and the fact that is very much a first class citizen in Ubuntu and backed by Canonical, I think Flutter deserves a home in Omakub.

### PR includes

- [x] install script
- [x] uninstall script
- [x] vscode support
- [x] neovim support

### Target Platforms
Out of the box this installation gives you the ability to target web and desktop linux:

![image](https://github.com/user-attachments/assets/d0e541b5-f1ca-4116-8319-393c0219b699)

### Editing & LSPs
Both the VS Code and Neovim setups appear to be working (but I am by no means a Vim user, so if anyone would like to validate this I would appreciate it).

### Links
- https://code.visualstudio.com/docs/editor/command-line
- https://github.com/akinsho/flutter-tools.nvim





