### PR TITLE
Avoid unnecessary detached HEAD state in `boot.sh` and check out `stable` branch in `migrate.sh`

### DIFF
--- a/bin/omakub-sub/migrate.sh
+++ b/bin/omakub-sub/migrate.sh
@@ -1,5 +1,6 @@
 cd $OMAKUB_PATH
 last_updated_at=$(git log -1 --format=%cd --date=unix)
+git checkout stable
 git pull
 
 for file in $OMAKUB_PATH/migrations/*.sh; do

--- a/boot.sh
+++ b/boot.sh
@@ -20,7 +20,7 @@ rm -rf ~/.local/share/omakub
 git clone https://github.com/basecamp/omakub.git ~/.local/share/omakub >/dev/null
 if [[ $OMAKUB_REF != "master" ]]; then
 	cd ~/.local/share/omakub
-	git fetch origin "${OMAKUB_REF:-stable}" && git checkout FETCH_HEAD
+	git fetch origin "${OMAKUB_REF:-stable}" && git checkout "${OMAKUB_REF:-stable}"
 	cd -
 fi
 


### PR DESCRIPTION
This is a follow-up to https://github.com/basecamp/omakub/pull/187 with the following changes:

- Ensure the stable branch is checked out before pulling in `migrate.sh`

  The checkout would be a no-op if already on `stable` (git would print `Already on 'stable'` but importantly would *not* return a failing exit code). It would fail if the user has local changes, but if they have local changes `git pull` would also fail, so there's no change there.

- Update `boot.sh` to avoid 'detached HEAD' state when not necessary

  Instead of checking out `FETCH_HEAD`, which always puts the user in 'detached HEAD' state, we will check out `${OMAKUB_REF:-stable}` so that we only end up in 'detached HEAD' state when necessary (i.e. when checking out a SHA rather than a branch).
  