### PR TITLE
Replace `Vitals` with `TopHat`

### DIFF
--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -16,7 +16,7 @@ gext install just-perfection-desktop@just-perfection
 gext install blur-my-shell@aunetx
 gext install space-bar@luchrioh
 gext install undecorate@sun.wxg@gmail.com
-gext install tophat@fflewddur
+gext install tophat@fflewddur.github.io
 gext install AlphabeticalAppGrid@stuarthayhurst
 
 # Compile gsettings schemas in order to be able to set them

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -16,7 +16,7 @@ gext install just-perfection-desktop@just-perfection
 gext install blur-my-shell@aunetx
 gext install space-bar@luchrioh
 gext install undecorate@sun.wxg@gmail.com
-gext install Vitals@CoreCoding.com
+gext install tophat@fflewddur
 gext install AlphabeticalAppGrid@stuarthayhurst
 
 # Compile gsettings schemas in order to be able to set them
@@ -24,7 +24,7 @@ sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnom
 sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/Vitals\@CoreCoding.com/schemas/org.gnome.shell.extensions.vitals.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
 
@@ -62,17 +62,6 @@ gsettings set org.gnome.shell.extensions.space-bar.behavior smart-workspace-name
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts enable-activate-workspace-shortcuts false
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts enable-move-to-workspace-shortcuts true
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts open-menu "@as []"
-
-# Configure Vitals
-gsettings set org.gnome.shell.extensions.vitals hide-icons true
-gsettings set org.gnome.shell.extensions.vitals hot-sensors "['__network-rx_max__']"
-gsettings set org.gnome.shell.extensions.vitals icon-style 0
-gsettings set org.gnome.shell.extensions.vitals network-speed-format 1
-
-# Unfortunately Vitals seems to maxout CPU on Intel, so let's turn it off by default there
-if grep -q "Intel" /proc/cpuinfo; then
-  gnome-extensions disable Vitals@CoreCoding.com
-fi
 
 # Configure AlphabeticalAppGrid
 gsettings set org.gnome.shell.extensions.alphabetical-app-grid folder-order-position 'end'

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -63,5 +63,11 @@ gsettings set org.gnome.shell.extensions.space-bar.shortcuts enable-activate-wor
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts enable-move-to-workspace-shortcuts true
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts open-menu "@as []"
 
+# Configure TopHat
+gsettings set org.gnome.shell.extensions.tophat show-icons false
+gsettings set org.gnome.shell.extensions.tophat show-cpu false
+gsettings set org.gnome.shell.extensions.tophat show-disk false
+gsettings set org.gnome.shell.extensions.tophat show-mem false
+
 # Configure AlphabeticalAppGrid
 gsettings set org.gnome.shell.extensions.alphabetical-app-grid folder-order-position 'end'

--- a/install/terminal/libraries.sh
+++ b/install/terminal/libraries.sh
@@ -1,5 +1,5 @@
 sudo apt install -y \
   build-essential pkg-config autoconf bison clang rustc \
   libssl-dev libreadline-dev zlib1g-dev libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libjemalloc2 \
-  libvips imagemagick libmagickwand-dev mupdf mupdf-tools \
+  libvips imagemagick libmagickwand-dev mupdf mupdf-tools gir1.2-gtop-2.0 gir1.2-clutter-1.0 \
   redis-tools sqlite3 libsqlite3-0 libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common


### PR DESCRIPTION
Since `Vitals` installation has been disabled for Intel processors, I think `TopHat` can be a great replacement as a monitoring extension. 

I searched for `TopHat` issues to see if anyone reported any malfunctions with Intel processors, similar to the one highlighted, but found nothing.

I made `TopHat` as similar as possible to the default `Vitals` configuration.