### PR TITLE
Replace `Vitals` with `TopHat` 

### DIFF
--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -2,17 +2,18 @@ THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa"
 THEME=$(gum choose "${THEME_NAMES[@]}" "<< Back" --header "Choose your theme" --height 10 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
 
 if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
-	cp $OMAKUB_PATH/themes/$THEME/alacritty.toml ~/.config/alacritty/theme.toml
-	cp $OMAKUB_PATH/themes/$THEME/zellij.kdl ~/.config/zellij/themes/$THEME.kdl
-	sed -i "s/theme \".*\"/theme \"$THEME\"/g" ~/.config/zellij/config.kdl
-	cp $OMAKUB_PATH/themes/$THEME/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
+  cp $OMAKUB_PATH/themes/$THEME/alacritty.toml ~/.config/alacritty/theme.toml
+  cp $OMAKUB_PATH/themes/$THEME/zellij.kdl ~/.config/zellij/themes/$THEME.kdl
+  sed -i "s/theme \".*\"/theme \"$THEME\"/g" ~/.config/zellij/config.kdl
+  cp $OMAKUB_PATH/themes/$THEME/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
 
-	source $OMAKUB_PATH/themes/$THEME/gnome.sh
-	source $OMAKUB_PATH/themes/$THEME/vscode.sh
+  source $OMAKUB_PATH/themes/$THEME/gnome.sh
+  source $OMAKUB_PATH/themes/$THEME/tophat.sh
+  source $OMAKUB_PATH/themes/$THEME/vscode.sh
 
-	# Forgo setting the Chrome theme until we might find a less disruptive way of doing it.
-	# Having to quit Chrome, and all Chrome-based apps, is too much of an inposition.
-	# source $OMAKUB_PATH/themes/$THEME/chrome.sh
+  # Forgo setting the Chrome theme until we might find a less disruptive way of doing it.
+  # Having to quit Chrome, and all Chrome-based apps, is too much of an inposition.
+  # source $OMAKUB_PATH/themes/$THEME/chrome.sh
 fi
 
 source $OMAKUB_PATH/bin/omakub-sub/menu.sh

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -16,7 +16,7 @@ gext install just-perfection-desktop@just-perfection
 gext install blur-my-shell@aunetx
 gext install space-bar@luchrioh
 gext install undecorate@sun.wxg@gmail.com
-gext install Vitals@CoreCoding.com
+gext install tophat@fflewddur.github.io
 gext install AlphabeticalAppGrid@stuarthayhurst
 
 # Compile gsettings schemas in order to be able to set them
@@ -24,7 +24,7 @@ sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnom
 sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/Vitals\@CoreCoding.com/schemas/org.gnome.shell.extensions.vitals.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
 
@@ -63,16 +63,12 @@ gsettings set org.gnome.shell.extensions.space-bar.shortcuts enable-activate-wor
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts enable-move-to-workspace-shortcuts true
 gsettings set org.gnome.shell.extensions.space-bar.shortcuts open-menu "@as []"
 
-# Configure Vitals
-gsettings set org.gnome.shell.extensions.vitals hide-icons true
-gsettings set org.gnome.shell.extensions.vitals hot-sensors "['__network-rx_max__']"
-gsettings set org.gnome.shell.extensions.vitals icon-style 0
-gsettings set org.gnome.shell.extensions.vitals network-speed-format 1
-
-# Unfortunately Vitals seems to maxout CPU on Intel, so let's turn it off by default there
-if grep -q "Intel" /proc/cpuinfo; then
-  gnome-extensions disable Vitals@CoreCoding.com
-fi
+# Configure TopHat
+gsettings set org.gnome.shell.extensions.tophat show-icons false
+gsettings set org.gnome.shell.extensions.tophat show-cpu false
+gsettings set org.gnome.shell.extensions.tophat show-disk false
+gsettings set org.gnome.shell.extensions.tophat show-mem false
+gsettings set org.gnome.shell.extensions.tophat network-usage-unit bits
 
 # Configure AlphabeticalAppGrid
 gsettings set org.gnome.shell.extensions.alphabetical-app-grid folder-order-position 'end'

--- a/install/desktop/set-gnome-theme.sh
+++ b/install/desktop/set-gnome-theme.sh
@@ -1,1 +1,2 @@
 source ~/.local/share/omakub/themes/tokyo-night/gnome.sh
+source ~/.local/share/omakub/themes/tokyo-night/tophat.sh

--- a/install/terminal/libraries.sh
+++ b/install/terminal/libraries.sh
@@ -1,5 +1,5 @@
 sudo apt install -y \
   build-essential pkg-config autoconf bison clang rustc \
   libssl-dev libreadline-dev zlib1g-dev libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libjemalloc2 \
-  libvips imagemagick libmagickwand-dev mupdf mupdf-tools \
+  libvips imagemagick libmagickwand-dev mupdf mupdf-tools gir1.2-gtop-2.0 gir1.2-clutter-1.0 \
   redis-tools sqlite3 libsqlite3-0 libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common

--- a/migrations/1723756122.sh
+++ b/migrations/1723756122.sh
@@ -1,0 +1,25 @@
+# Uninstall Vitals
+if [ -n "$(gnome-extensions list | grep Vitals@CoreCoding.com)" ]; then
+  gnome-extensions uninstall Vitals@CoreCoding.com
+fi
+
+# Install TopHat
+gext install tophat@fflewddur.github.io
+
+sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
+sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+
+# Configure TopHat
+gsettings set org.gnome.shell.extensions.tophat show-icons false
+gsettings set org.gnome.shell.extensions.tophat show-cpu false
+gsettings set org.gnome.shell.extensions.tophat show-disk false
+gsettings set org.gnome.shell.extensions.tophat show-mem false
+gsettings set org.gnome.shell.extensions.tophat network-usage-unit bits
+
+# Set TopHat metrics color to match the theme
+THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa" "Rose Pine")
+THEME=$(gum choose "${THEME_NAMES[@]}" "Default" --header "Choose your theme" --height 10 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
+
+if [ -n "$THEME" ] && [ "$THEME" != "default" ]; then
+  source $OMAKUB_PATH/themes/$THEME/tophat.sh
+fi

--- a/themes/catppuccin/tophat.sh
+++ b/themes/catppuccin/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#e920a3"

--- a/themes/everforest/tophat.sh
+++ b/themes/everforest/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"

--- a/themes/gruvbox/tophat.sh
+++ b/themes/gruvbox/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"

--- a/themes/kanagawa/tophat.sh
+++ b/themes/kanagawa/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"

--- a/themes/nord/tophat.sh
+++ b/themes/nord/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#208fe9"

--- a/themes/rose-pine/tophat.sh
+++ b/themes/rose-pine/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#e92020"

--- a/themes/tokyo-night/tophat.sh
+++ b/themes/tokyo-night/tophat.sh
@@ -1,0 +1,1 @@
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"


### PR DESCRIPTION
Since `Vitals` installation has been disabled for Intel processors, I think `TopHat` can be a great replacement as a monitoring extension. 

I searched for `TopHat` issues to see if anyone reported any malfunctions with Intel processors, similar to the one highlighted, but found nothing.

I made `TopHat` as similar as possible to the default `Vitals` configuration.