### PR TITLE
Add move-to-workspace hotkeys

### DIFF
--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -36,6 +36,14 @@ gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-4 "['<Super>4
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5']"
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
 
+# Use shift super for move application to workspace
+gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-1 "['<Shift><Super>1']"
+gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-2 "['<Shift><Super>2']"
+gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-3 "['<Shift><Super>3']"
+gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-4 "['<Shift><Super>4']"
+gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-5 "['<Shift><Super>5']"
+gsettings set org.gnome.desktop.wm.keybindings move-to-workspace-6 "['<Shift><Super>6']"
+
 # Reserve slots for custom keybindings
 gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']"
 


### PR DESCRIPTION
I think these hotkeys can be useful to have to keep alive the philosophy of using the keyboard as much as possible, instead of the mouse. 

To move open applications between workspaces and have everything organized, these hotkeys may be what the user needs.

The added shortcuts are: 

```
Shift+Super+1 - Move application to Workspace 1
Shift+Super+2 - Move application to Workspace 2
Shift+Super+3 - Move application to Workspace 3
Shift+Super+4 - Move application to Workspace 4
Shift+Super+5 - Move application to Workspace 5
Shift+Super+6 - Move application to Workspace 6
```