### PR TITLE
Fix missing `TopHat` libraries in migration

### DIFF
--- a/migrations/1723756122.sh
+++ b/migrations/1723756122.sh
@@ -3,6 +3,9 @@ if [ -n "$(gnome-extensions list | grep Vitals@CoreCoding.com)" ]; then
   gnome-extensions uninstall Vitals@CoreCoding.com
 fi
 
+# Install Tophat libraries
+sudo apt install -y gir1.2-gtop-2.0 gir1.2-clutter-1.0
+
 # Install TopHat
 gext install tophat@fflewddur.github.io
 
@@ -23,3 +26,6 @@ THEME=$(gum choose "${THEME_NAMES[@]}" "Default" --header "Choose your theme" --
 if [ -n "$THEME" ] && [ "$THEME" != "default" ]; then
   source $OMAKUB_PATH/themes/$THEME/tophat.sh
 fi
+
+# Logout
+gum confirm "Ready to logout for all settings to take effect?" && gnome-session-quit --logout --no-prompt


### PR DESCRIPTION
This commit fixes the TopHat libraries missing error after running the migration script.

[Reference](https://github.com/basecamp/omakub/pull/245#issuecomment-2304633085)