### PR TITLE
Add fastfetch config 

### DIFF
--- a/configs/fastfetch.jsonc
+++ b/configs/fastfetch.jsonc
@@ -1,0 +1,143 @@
+{
+    "$schema": "https://github.com/fastfetch-cli/fastfetch/raw/dev/doc/json_schema.json",
+    "logo": {
+        "padding": {
+            "top": 5,
+            "right": 6
+        }
+    },
+    "modules": [
+        "break",
+        {
+            "type": "custom",
+            "format": "\u001b[90m┌──────────────────────Hardware──────────────────────┐"
+        },
+        {
+            "type": "host",
+            "key": " PC",
+            "keyColor": "green"
+        },
+        {
+            "type": "cpu",
+            "key": "│ ├",
+            "showPeCoreCount": true,
+            "keyColor": "green"
+        },
+        {
+            "type": "gpu",
+            "key": "│ ├",
+            "detectionMethod": "pci",
+            "keyColor": "green"
+        },
+        {
+            "type": "display",
+            "key": "│ ├󱄄",
+            "keyColor": "green"
+        },
+        {
+            "type": "disk",
+            "key": "│ ├󰋊",
+            "keyColor": "green"
+        },
+        {
+            "type": "memory",
+            "key": "│ ├",
+            "keyColor": "green"
+        },
+        {
+            "type": "swap",
+            "key": "└ └󰓡 ",
+            "keyColor": "green",
+        },
+        {
+            "type": "custom",
+            "format": "\u001b[90m└────────────────────────────────────────────────────┘"
+        },
+        "break",
+        {
+            "type": "custom",
+            "format": "\u001b[90m┌──────────────────────Software──────────────────────┐"
+        },
+        {
+            "type": "os",
+            "key": " OS",
+            "keyColor": "yellow"
+        },
+        {
+            "type": "kernel",
+            "key": "│ ├",
+            "keyColor": "yellow"
+        },
+        {
+            "type": "packages",
+            "key": "│ ├󰏖",
+            "keyColor": "yellow"
+        },
+        {
+            "type": "shell",
+            "key": "└ └",
+            "keyColor": "yellow"
+        },
+        "break",
+        {
+            "type": "de",
+            "key": " DE",
+            "keyColor": "blue"
+        },
+        {
+            "type": "wm",
+            "key": "│ ├",
+            "keyColor": "blue"
+        },
+        {
+            "type": "wmtheme",
+            "key": "│ ├󰉼",
+            "keyColor": "blue"
+        },
+        {
+            "type": "icons",
+            "key": "│ ├󰀻",
+            "keyColor": "blue",
+        },
+        {
+            "type": "cursor",
+            "key": "│ ├",
+            "keyColor": "blue",
+        },
+        {
+            "type": "terminalfont",
+            "key": "│ ├",
+            "keyColor": "blue",
+        },
+        {
+            "type": "terminal",
+            "key": "└ └",
+            "keyColor": "blue"
+        },
+        {
+            "type": "custom",
+            "format": "\u001b[90m└────────────────────────────────────────────────────┘"
+        },
+        "break",
+        {
+            "type": "custom",
+            "format": "\u001b[90m┌────────────────────Uptime / Age────────────────────┐"
+        },
+        {
+            "type": "command",
+            "key": "  OS Age ",
+            "keyColor": "magenta",
+            "text": "birth_install=$(stat -c %W /); current=$(date +%s); time_progression=$((current - birth_install)); days_difference=$((time_progression / 86400)); echo $days_difference days"
+        },
+        {
+            "type": "uptime",
+            "key": "  Uptime ",
+            "keyColor": "magenta"
+        },
+        {
+            "type": "custom",
+            "format": "\u001b[90m└────────────────────────────────────────────────────┘"
+        },
+        "break",
+    ]
+}

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -2,3 +2,10 @@
 sudo add-apt-repository -y ppa:zhangsongcui3371/fastfetch
 sudo apt update -y
 sudo apt install -y fastfetch
+
+# Only attempt to set configuration if fastfetch is not already set
+if [ ! -f "$HOME/.config/fastfetch/config.jsonc" ]; then
+  # Use Omakub fastfetch config
+  mkdir -p ~/.config/fastfetch
+  cp ~/.local/share/omakub/configs/fastfetch.jsonc ~/.config/fastfetch/config.jsonc
+fi

--- a/migrations/1724344367.sh
+++ b/migrations/1724344367.sh
@@ -1,0 +1,11 @@
+# Check if fastfetch config.jsonc is already set
+if [ -f "$HOME/.config/fastfetch/config.jsonc" ]; then
+  gum confirm "It appears that a fastfetch configuration is already set. Do you want to overwrite it?" && rm "$HOME/.config/fastfetch/config.jsonc"
+fi
+
+# Only attempt to set configuration if fastfetch is not already set
+if [ ! -f "$HOME/.config/fastfetch/config.jsonc" ]; then
+  # Use Omakub fastfetch config
+  mkdir -p ~/.config/fastfetch
+  cp "$OMAKUB_PATH/configs/fastfetch.jsonc" ~/.config/fastfetch/config.jsonc
+fi


### PR DESCRIPTION
Added a config file for `fastfetch` during installation so About and the command `fastfetch` can provide only the most relevant information in more modern way than default one. I applied a variant of the [XeroLinux's Layan Rice](https://github.com/xerolinux/xero-layan-git) with some small tweaks. 

I have already added the migration file with the option to preserve any configurations already applied in `.config/fastfetch`.

Here a screenshot:

![image](https://github.com/user-attachments/assets/47233ef3-2499-4349-a5ac-1d35ce15171a)
