### PR TITLE
Use flatpak for Pinta installation

### DIFF
--- a/install/desktop/app-pinta.sh
+++ b/install/desktop/app-pinta.sh
@@ -1,2 +1,2 @@
-# FIXME: Get this out of snap
-sudo snap install pinta
+# Pinta is a free, open source program for drawing and image editing. See https://www.pinta-project.com/
+flatpak install -y flathub com.github.PintaProject.Pinta

--- a/migrations/1724620387.sh
+++ b/migrations/1724620387.sh
@@ -1,0 +1,3 @@
+# Uninstall Pinta snap version and install the flatpak version
+sudo snap remove pinta
+flatpak install -y flathub com.github.PintaProject.Pinta

--- a/uninstall/app-pinta.sh
+++ b/uninstall/app-pinta.sh
@@ -1,1 +1,1 @@
-sudo snap remove pinta
+flatpak uninstall -y flathub com.github.PintaProject.Pinta


### PR DESCRIPTION
Resolve a `FIXME` left in the Pinta installation, replacing `snap` with `flatpak`.