### PR TITLE
restore original idle and lock settings instead of defaults

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,9 @@ source ~/.local/share/omakub/install/check-version.sh
 
 if $RUNNING_GNOME; then
   # Ensure computer doesn't go to sleep or lock while installing
+  LOCK_ENABLED_ORIGINAL_VALUE="$(gsettings get org.gnome.desktop.screensaver lock-enabled)"
   gsettings set org.gnome.desktop.screensaver lock-enabled false
+  IDLE_DELAY_ORIGINAL_VALUE="$(gsettings get org.gnome.desktop.session idle-delay)"
   gsettings set org.gnome.desktop.session idle-delay 0
 
   echo "Get ready to make a few choices..."
@@ -28,7 +30,7 @@ if $RUNNING_GNOME; then
   # Install desktop tools and tweaks
   source ~/.local/share/omakub/install/desktop.sh
 
-  # Revert to normal idle and lock settings
-  gsettings set org.gnome.desktop.screensaver lock-enabled true
-  gsettings set org.gnome.desktop.session idle-delay 300
+  # Revert to original idle and lock settings
+  gsettings set org.gnome.desktop.screensaver lock-enabled "${LOCK_ENABLED_ORIGINAL_VALUE}"
+  gsettings set org.gnome.desktop.session idle-delay "${IDLE_DELAY_ORIGINAL_VALUE}"
 fi


### PR DESCRIPTION
At the end of the installation, restore the original idle-delay and lock-enabled Gnome settings instead of default values.