### PR TITLE
Added arm support to the installation script.

### DIFF
--- a/install/desktop/app-chrome.sh
+++ b/install/desktop/app-chrome.sh
@@ -1,6 +1,7 @@
 # Browse the web with the most popular browser. See https://www.google.com/chrome/
 if [ "$(dpkg --print-architecture)" = "arm64" ]; then
     sudo apt install -y chromium-browser
+    xdg-settings set default-web-browser chromium-browser.desktop
 else
     cd /tmp
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb

--- a/install/desktop/app-chrome.sh
+++ b/install/desktop/app-chrome.sh
@@ -1,7 +1,11 @@
 # Browse the web with the most popular browser. See https://www.google.com/chrome/
-cd /tmp
-wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-sudo apt install -y ./google-chrome-stable_current_amd64.deb
-rm google-chrome-stable_current_amd64.deb
-xdg-settings set default-web-browser google-chrome.desktop
-cd -
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    sudo apt install -y chromium-browser
+else
+    cd /tmp
+    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    sudo apt install -y ./google-chrome-stable_current_amd64.deb
+    rm google-chrome-stable_current_amd64.deb
+    xdg-settings set default-web-browser google-chrome.desktop
+    cd -
+fi

--- a/install/desktop/app-localsend.sh
+++ b/install/desktop/app-localsend.sh
@@ -1,7 +1,10 @@
-cd /tmp
-LOCALSEND_VERSION=$(curl -s "https://api.github.com/repos/localsend/localsend/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "arm-64" || echo "x86-64")
-wget -O localsend.deb "https://github.com/localsend/localsend/releases/latest/download/LocalSend-${LOCALSEND_VERSION}-linux-${TARGET_ARCH}.deb"
-sudo apt install -y ./localsend.deb
-rm localsend.deb
-cd -
+if [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    snap install localsend
+else
+    cd /tmp
+    LOCALSEND_VERSION=$(curl -s "https://api.github.com/repos/localsend/localsend/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+    wget -O localsend.deb "https://github.com/localsend/localsend/releases/latest/download/LocalSend-${LOCALSEND_VERSION}-linux-x86-64.deb"
+    sudo apt install -y ./localsend.deb
+    rm localsend.deb
+    cd -
+fi

--- a/install/desktop/app-localsend.sh
+++ b/install/desktop/app-localsend.sh
@@ -1,6 +1,7 @@
 cd /tmp
 LOCALSEND_VERSION=$(curl -s "https://api.github.com/repos/localsend/localsend/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-wget -O localsend.deb "https://github.com/localsend/localsend/releases/latest/download/LocalSend-${LOCALSEND_VERSION}-linux-x86-64.deb"
+TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "arm-64" || echo "x86-64")
+wget -O localsend.deb "https://github.com/localsend/localsend/releases/latest/download/LocalSend-${LOCALSEND_VERSION}-linux-${TARGET_ARCH}.deb"
 sudo apt install -y ./localsend.deb
 rm localsend.deb
 cd -

--- a/install/desktop/app-signal.sh
+++ b/install/desktop/app-signal.sh
@@ -1,3 +1,6 @@
+if [ "$(uname -m)" = "aarch64" ]; then
+    sudo snap install signal-desktop
+else
 wget -qO- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor >signal-desktop-keyring.gpg
 cat signal-desktop-keyring.gpg | sudo tee /usr/share/keyrings/signal-desktop-keyring.gpg >/dev/null
 echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main' |
@@ -5,3 +8,4 @@ echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] 
 rm signal-desktop-keyring.gpg
 sudo apt update
 sudo apt install -y signal-desktop
+fi

--- a/install/desktop/app-vscode.sh
+++ b/install/desktop/app-vscode.sh
@@ -1,5 +1,6 @@
 cd /tmp
-wget -O code.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-x64'
+TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "arm64" || echo "x64")
+wget -O code.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-${TARGET_ARCH}'
 sudo apt install -y ./code.deb
 rm code.deb
 cd -

--- a/install/desktop/app-vscode.sh
+++ b/install/desktop/app-vscode.sh
@@ -1,5 +1,5 @@
 cd /tmp
-TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "arm64" || echo "x64")
+TARGET_ARCH=$([ "$(dpkg --print-architecture)" = "arm64" ] && echo "arm64" || echo "x64")
 wget -O code.deb "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-${TARGET_ARCH}"
 sudo apt install -y ./code.deb
 rm code.deb

--- a/install/desktop/app-vscode.sh
+++ b/install/desktop/app-vscode.sh
@@ -1,6 +1,6 @@
 cd /tmp
 TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "arm64" || echo "x64")
-wget -O code.deb 'https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-${TARGET_ARCH}'
+wget -O code.deb "https://code.visualstudio.com/sha/download?build=stable&os=linux-deb-${TARGET_ARCH}"
 sudo apt install -y ./code.deb
 rm code.deb
 cd -

--- a/install/desktop/optional/app-zoom.sh
+++ b/install/desktop/optional/app-zoom.sh
@@ -1,6 +1,8 @@
 # Make video calls using https://zoom.us/
-cd /tmp
-wget https://zoom.us/client/latest/zoom_amd64.deb
-sudo apt install -y ./zoom_amd64.deb
-rm zoom_amd64.deb
-cd -
+if [ $(dpkg --print-architecture) != "arm64" ]; then
+    cd /tmp
+    wget https://zoom.us/client/latest/zoom_amd64.deb
+    sudo apt install -y ./zoom_amd64.deb
+    rm zoom_amd64.deb
+    cd -
+fi

--- a/install/terminal/app-lazydocker.sh
+++ b/install/terminal/app-lazydocker.sh
@@ -1,6 +1,7 @@
 cd /tmp
 LAZYDOCKER_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazydocker/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -sLo lazydocker.tar.gz "https://github.com/jesseduffield/lazydocker/releases/latest/download/lazydocker_${LAZYDOCKER_VERSION}_Linux_x86_64.tar.gz"
+TARGET_ARCH=$(dpkg --print-architecture)
+curl -sLo lazydocker.tar.gz "https://github.com/jesseduffield/lazydocker/releases/latest/download/lazydocker_${LAZYDOCKER_VERSION}_Linux_${TARGET_ARCH}.tar.gz"
 tar -xf lazydocker.tar.gz lazydocker
 sudo install lazydocker /usr/local/bin
 rm lazydocker.tar.gz lazydocker

--- a/install/terminal/app-lazygit.sh
+++ b/install/terminal/app-lazygit.sh
@@ -1,6 +1,7 @@
 cd /tmp
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
-curl -sLo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
+TARGET_ARCH=$(dpkg --print-architecture)
+curl -sLo lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_${TARGET_ARCH}.tar.gz"
 tar -xf lazygit.tar.gz lazygit
 sudo install lazygit /usr/local/bin
 rm lazygit.tar.gz lazygit

--- a/install/terminal/app-zellij.sh
+++ b/install/terminal/app-zellij.sh
@@ -1,5 +1,5 @@
 cd /tmp
-TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "aarch64" || echo "x86_64")
+TARGET_ARCH=$([ "$(dpkg --print-architecture)" = "arm64" ] && echo "aarch64" || echo "x86_64")
 wget -O zellij.tar.gz "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${TARGET_ARCH}-unknown-linux-musl.tar.gz"
 tar -xf zellij.tar.gz zellij
 sudo install zellij /usr/local/bin

--- a/install/terminal/app-zellij.sh
+++ b/install/terminal/app-zellij.sh
@@ -1,5 +1,6 @@
 cd /tmp
-wget -O zellij.tar.gz "https://github.com/zellij-org/zellij/releases/latest/download/zellij-x86_64-unknown-linux-musl.tar.gz"
+TARGET_ARCH=$(["$(dpkg --print-architecture)" = "arm64"] && echo "aarch64" || echo "x86_64")
+wget -O zellij.tar.gz "https://github.com/zellij-org/zellij/releases/latest/download/zellij-${TARGET_ARCH}-unknown-linux-musl.tar.gz"
 tar -xf zellij.tar.gz zellij
 sudo install zellij /usr/local/bin
 rm zellij.tar.gz zellij

--- a/install/terminal/mise.sh
+++ b/install/terminal/mise.sh
@@ -2,6 +2,6 @@
 sudo apt update -y && sudo apt install -y gpg sudo wget curl
 sudo install -dm 755 /etc/apt/keyrings
 wget -qO - https://mise.jdx.dev/gpg-key.pub | gpg --dearmor | sudo tee /etc/apt/keyrings/mise-archive-keyring.gpg 1>/dev/null
-echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
+echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
 sudo apt update
 sudo apt install -y mise

--- a/install/terminal/required/app-gum.sh
+++ b/install/terminal/required/app-gum.sh
@@ -1,7 +1,8 @@
 # Gum is used for the Omakub commands for tailoring Omakub after the initial install
 cd /tmp
 GUM_VERSION="0.14.3" # Use known good version
-wget -qO gum.deb "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_amd64.deb"
+TARGET_ARCH=$(dpkg --print-architecture)
+wget -qO gum.deb "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_${TARGET_ARCH}.deb"
 sudo apt-get install -y ./gum.deb
 rm gum.deb
 cd -


### PR DESCRIPTION
- I debugged and added a platform check to ensure that Arm64 packages are installed for arm-based systems.
- I used Snap where direct arm package installation was not possible: fcae05ac604a989aec0085cf5b7a9068122ce598, 9e0700373c7dfe43dfbbbb35497848a1e07dec3d
- Does not install packages where the arm version is unavailable: 3f4d7fe5cd0f6e64afbda7ee260a0d8ce7aa8af5
- Installed chromium instead of chrome because it is not available on Arm64: 9e0700373c7dfe43dfbbbb35497848a1e07dec3d, b96606bd38d38e9ec80edb10070d871b5b0b0fd1

The install script works for a fresh Ubuntu 24.04 arm64 server with tasksel and ubuntu-desktop installed. 
[YouTube Video to try it with UTM on MacBook Pro M series laptops.](https://youtu.be/nUhQy5PDj2A?si=RfJo2sn5uS6uLeXt)
