### PR TITLE
Docker + ufw integration

### DIFF
--- a/install/ufw.sh
+++ b/install/ufw.sh
@@ -1,2 +1,10 @@
+sudo wget -O /usr/local/bin/ufw-docker https://github.com/chaifeng/ufw-docker/raw/master/ufw-docker
+sudo chmod +x /usr/local/bin/ufw-docker
+
+sudo ufw-docker install
+
 sudo ufw enable
+sudo ufw reload # Pull in new rules if already enabled
+
 sudo ufw show verbose
+sudo ufw-docker check

--- a/migrations/1724342593.sh
+++ b/migrations/1724342593.sh
@@ -1,0 +1,6 @@
+echo "Integrating ufw firewall with Docker..."
+
+# Drop "iptables": false option
+echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json
+
+source $OMAKUB_PATH/install/ufw.sh


### PR DESCRIPTION
We disabled iptables integration in #104. Time to reintroduce it with ufw managing what Docker exposes.

/cc @gregmolnar 