### PR TITLE
Switch PHP's default LSP to intelephense instead of phpactor

### DIFF
--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -25,6 +25,11 @@ if [[ -n "$languages" ]]; then
 			php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 			php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
 			rm composer-setup.php
+
+			# Configure PHP's LSP to use intelephense instead of phpactor (default)
+			if ! grep -q 'php_lsp' ~/.config/nvim/lua/config/options.lua; then
+				echo 'vim.g.lazyvim_php_lsp = "intelephense"' >>~/.config/nvim/lua/config/options.lua
+			fi
 			;;
 		Python)
 			mise use --global python@latest


### PR DESCRIPTION
### Changelog

- Changes the LSP to intelephense instead of the default (phpactor) - intelephense is much less verbose, IMO, it's the one I prefer using myself and also the one I use in VSCode (there's a comparison [here](https://yarnaudov.com/phpactor-vs-intelephense.html)), I made a patch to LazyVim to support it (https://github.com/LazyVim/LazyVim/pull/3691)

---

I started this work at https://github.com/basecamp/omakub/pull/156, but it was mixed with https://github.com/basecamp/omakub/pull/269, so I've decided to send two separate PRs