### PR TITLE
Headless installation patch

### DIFF
--- a/defaults/bash/shell
+++ b/defaults/bash/shell
@@ -5,6 +5,9 @@ HISTSIZE=32768
 HISTFILESIZE="${HISTSIZE}"
 
 # Autocompletion
+if [ ! -f /usr/share/bash-completion/bash_completion ]; then
+    sudo apt install -y bash-completion
+fi
 source /usr/share/bash-completion/bash_completion
 
 # Set complete path

--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -9,7 +9,7 @@ fi
 . /etc/os-release
 
 # Check if running on Ubuntu 24.04 or higher
-if [ "$ID" != "ubuntu" ] || [ $(echo "$VERSION_ID >= 24.04" | bc) != 1 ]; then
+if [ "$ID" != "ubuntu" ] || [ $(python3 -c "print(float('$VERSION_ID') >= 24.04)") != 1 ]; then
     echo "$(tput setaf 1)Error: OS requirement not met"
     echo "You are currently running: $ID $VERSION_ID"
     echo "OS required: ubuntu 24.04 or higher"

--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -9,7 +9,7 @@ fi
 . /etc/os-release
 
 # Check if running on Ubuntu 24.04 or higher
-if [ "$ID" != "ubuntu" ] || [ $(python3 -c "print(float('$VERSION_ID') >= 24.04)") != 1 ]; then
+if [ "$ID" != "ubuntu" ] || [ $(python3 -c "print(int(float('$VERSION_ID') >= 24.04))") != 1 ]; then
     echo "$(tput setaf 1)Error: OS requirement not met"
     echo "You are currently running: $ID $VERSION_ID"
     echo "OS required: ubuntu 24.04 or higher"

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,5 +3,8 @@ sudo apt update -y
 sudo apt upgrade -y
 sudo apt install -y curl git unzip
 
+# Run required installers first
+for installer in ~/.local/share/omakub/install/terminal/required/*.sh; do source $installer; done
+
 # Run terminal installers
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,7 +3,7 @@ sudo apt update -y
 sudo apt upgrade -y
 sudo apt install -y curl git unzip
 
-# Run required installers first
+# Ensure required installers first
 for installer in ~/.local/share/omakub/install/terminal/required/*.sh; do source $installer; done
 
 # Run terminal installers

--- a/install/terminal/app-fzf.sh
+++ b/install/terminal/app-fzf.sh
@@ -1,0 +1,6 @@
+# Install fzf with key-bindings ensured
+sudo apt install -y fzf
+
+if [[ ! -f /usr/share/doc/fzf/examples/key-bindings.bash ]]; then
+  sudo curl https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.bash -o /usr/share/doc/fzf/examples/key-bindings.bash
+fi

--- a/install/terminal/apps-terminal.sh
+++ b/install/terminal/apps-terminal.sh
@@ -1,1 +1,1 @@
-sudo apt install -y bash-completion ripgrep bat eza zoxide plocate btop apache2-utils fd-find tldr
+sudo apt install -y ripgrep bat eza zoxide plocate btop apache2-utils fd-find tldr

--- a/install/terminal/apps-terminal.sh
+++ b/install/terminal/apps-terminal.sh
@@ -1,1 +1,1 @@
-sudo apt install -y fzf ripgrep bat eza zoxide plocate btop apache2-utils fd-find tldr
+sudo apt install -y bash-completion ripgrep bat eza zoxide plocate btop apache2-utils fd-find tldr

--- a/install/terminal/required/app-gum.sh
+++ b/install/terminal/required/app-gum.sh
@@ -1,4 +1,4 @@
-# Gum is used for the Omakub commands for tailoring Omakub after the initial install
+# Gum is used for the Omakub commands for tailoring Omakub
 cd /tmp
 GUM_VERSION="0.14.3" # Use known good version
 wget -qO gum.deb "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_amd64.deb"

--- a/install/terminal/required/apt-add-reporsitory.sh
+++ b/install/terminal/required/apt-add-reporsitory.sh
@@ -1,0 +1,7 @@
+# Add add-apt-repository when not available
+
+# Check if add-apt-repository is available
+if ! command -v add-apt-repository &> /dev/null; then
+    # Install software-properties-common
+    sudo apt-get install -y software-properties-common
+fi


### PR DESCRIPTION
Major changes:
1. Fixed install order on Pure Terminal Installation (`Gum` should now be correctly installed before install/terminal/select-dev-*.sh scripts)
2. Fixed a potential missing requirement for installing 3rd party apps (`apt-add-repository` is now ensured to exist for install/terminal/app-fastfetch.sh)
3. Replacing `bc` dependency with `python3` dependency for version confirming (As `bc` was missing in my test environment, and now `python3` is required by grub2, this should be a safe dependency shift)

Minor fixes:
1. Ensuring `fzf` key-binds script always exists (Otherwise, it might cause an issue after sourcing defaults/bash/init)

Tested environment:
Docker hub image nvidia/cuda:12.6.0-devel-ubuntu24.04 in vscode dev container.