### PR TITLE
feat: additional error handling safety to install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
-# Exit immediately if a command exits with a non-zero status
-set -e
+# Exit immediately if a command fails, treat unset variables as an error and ensure all parts of pipelines fail properly
+set -euo pipefail
 
 # Desktop software and tweaks will only be installed if we're running Gnome
 RUNNING_GNOME=$([[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] && echo true || echo false)


### PR DESCRIPTION
This update enhances the robustness of the installation script by replacing `set -e` with `set -euo pipefail`. This change ensures:

- The script exits immediately if a command fails (`-e`),
- Any attempt to use an unset variable is treated as an error (`-u`),
- Errors in any part of a pipeline are detected and handled properly (`pipefail`).
- This adjustment provides stronger safeguards and prevents potential issues during system configuration.

Appreciate there are no pipelines in this script, but taking the chance to add it now as there could be in future.

Please review and let me know if any further adjustments are needed. Thank you!
