### PR TITLE
Adding xclip for allowing nvim to copy to the system clipboard

### DIFF
--- a/install/terminal/libraries.sh
+++ b/install/terminal/libraries.sh
@@ -2,4 +2,4 @@ sudo apt install -y \
   build-essential pkg-config autoconf bison clang rustc \
   libssl-dev libreadline-dev zlib1g-dev libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libjemalloc2 \
   libvips imagemagick libmagickwand-dev mupdf mupdf-tools gir1.2-gtop-2.0 gir1.2-clutter-1.0 \
-  redis-tools sqlite3 libsqlite3-0 libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common
+  redis-tools sqlite3 libsqlite3-0 libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common xclip


### PR DESCRIPTION
Right now if you try to copy something to the system clipboard in neovim, you get an error 
> 650 lines yanked into "+ <br> clipboard: No provider. Try ":checkhealth" or ":h clipboard".

In my case I was trynig to copy the entire file with gg"+yG (goto top and copy to bottom into system clipboard)

After installing xclip, it worked for me.