### PR TITLE
Check for VS Code before setting theme

### DIFF
--- a/themes/set-vscode-theme.sh
+++ b/themes/set-vscode-theme.sh
@@ -1,2 +1,4 @@
-code --install-extension $VSC_EXTENSION >/dev/null
-sed -i "s/\"workbench.colorTheme\": \".*\"/\"workbench.colorTheme\": \"$VSC_THEME\"/g" ~/.config/Code/User/settings.json
+if command -v code &>/dev/null; then
+  code --install-extension $VSC_EXTENSION >/dev/null
+  sed -i "s/\"workbench.colorTheme\": \".*\"/\"workbench.colorTheme\": \"$VSC_THEME\"/g" ~/.config/Code/User/settings.json
+fi


### PR DESCRIPTION
Adds a check to see if VS Code is installed before installing theme extension and setting the theme.

Closes #288
