### PR TITLE
adjust sleep-prevention strategy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,10 @@ RUNNING_GNOME=$([[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] && echo true || echo f
 source ~/.local/share/omakub/install/check-version.sh
 
 if $RUNNING_GNOME; then
+  # Try to respect any previously configured settings
+  previous_screensaver_lock=$(gsettings get org.gnome.desktop.screensaver lock-enabled) || true
+  previous_idle_delay=$(gsettings get org.gnome.desktop.session idle-delay | cut -d\  -f2) || true
+
   # Ensure computer doesn't go to sleep or lock while installing
   gsettings set org.gnome.desktop.screensaver lock-enabled false
   gsettings set org.gnome.desktop.session idle-delay 0
@@ -28,7 +32,7 @@ if $RUNNING_GNOME; then
   # Install desktop tools and tweaks
   source ~/.local/share/omakub/install/desktop.sh
 
-  # Revert to normal idle and lock settings
-  gsettings set org.gnome.desktop.screensaver lock-enabled true
-  gsettings set org.gnome.desktop.session idle-delay 300
+  # Restore idle and lock settings
+  gsettings set org.gnome.desktop.screensaver lock-enabled ${previous_screensaver_lock:-true}
+  gsettings set org.gnome.desktop.session idle-delay ${previous_idle_delay:-300}
 fi

--- a/install.sh
+++ b/install.sh
@@ -8,10 +8,6 @@ RUNNING_GNOME=$([[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] && echo true || echo f
 source ~/.local/share/omakub/install/check-version.sh
 
 if $RUNNING_GNOME; then
-  # Try to respect any previously configured settings
-  previous_screensaver_lock=$(gsettings get org.gnome.desktop.screensaver lock-enabled) || true
-  previous_idle_delay=$(gsettings get org.gnome.desktop.session idle-delay | cut -d\  -f2) || true
-
   # Ensure computer doesn't go to sleep or lock while installing
   gsettings set org.gnome.desktop.screensaver lock-enabled false
   gsettings set org.gnome.desktop.session idle-delay 0
@@ -21,18 +17,14 @@ if $RUNNING_GNOME; then
   source ~/.local/share/omakub/install/first-run-choices.sh
 
   echo "Installing terminal and desktop tools.."
-else
-  echo "Only installing terminal tools..."
-fi
-
-# Install terminal tools
-source ~/.local/share/omakub/install/terminal.sh
-
-if $RUNNING_GNOME; then
   # Install desktop tools and tweaks
-  source ~/.local/share/omakub/install/desktop.sh
+  source ~/.local/share/omakub/install/{terminal,desktop}.sh
 
   # Restore idle and lock settings
-  gsettings set org.gnome.desktop.screensaver lock-enabled ${previous_screensaver_lock:-true}
-  gsettings set org.gnome.desktop.session idle-delay ${previous_idle_delay:-300}
+  gsettings set org.gnome.desktop.screensaver lock-enabled $previous_screensaver_lock
+  gsettings set org.gnome.desktop.session idle-delay $previous_idle_delay
+else
+  echo "Only installing terminal tools..."
+	# Install terminal tools
+	source ~/.local/share/omakub/install/terminal.sh
 fi

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -1,13 +1,5 @@
-# Ensure computer doesn't go to sleep or lock while installing
-gsettings set org.gnome.desktop.screensaver lock-enabled false
-gsettings set org.gnome.desktop.session idle-delay 0
-
 # Run desktop installers
 for installer in ~/.local/share/omakub/install/desktop/*.sh; do source $installer; done
-
-# Revert to normal idle and lock settings
-gsettings set org.gnome.desktop.screensaver lock-enabled true
-gsettings set org.gnome.desktop.session idle-delay 300
 
 # Logout to pickup changes
 gum confirm "Ready to reboot for all settings to take effect?" && sudo reboot


### PR DESCRIPTION
[UPDATED]
Removes redundant idle and lock settings changes from install/desktop.sh and moves the restoring of said settings into install.sh

(Explanation):
install.sh disables sleep by overwriting the session idle delay time and screensaver lock screen settings.
If the desktop environment is Gnome, it calls install/desktop.sh which begins with the exact same lines for disabling sleep.
No other file in the codebase directly calls install/desktop.sh and so there is no reason to repeat these lines - if install/desktop.sh is being ran then sleep will have already be disabled.
However, install/desktop.sh was the only place where those settings were being re-enabled; and since it only gets ran if the desktop environment is Gnome, it made sense just move that part out to install.sh so that both paths (desktop & terminal) could have their settings re-enabled.

I also consolidated the double if conditional and the Gnome check into a single if/else.