### PR TITLE
Use FZF to select theme

### DIFF
--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -1,5 +1,5 @@
-THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa" "Rose Pine")
-THEME=$(gum choose "${THEME_NAMES[@]}" "<< Back" --header "Choose your theme" --height 10 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
+THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa" "Rose Pine" "<< Back")
+THEME=$(printf "%s\n" "${THEME_NAMES[@]}" | fzf --header "Choose your theme" --layout=reverse --height 11 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
 
 if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
   cp $OMAKUB_PATH/themes/$THEME/alacritty.toml ~/.config/alacritty/theme.toml


### PR DESCRIPTION
I have a slightly different theme script, but it should work with Omakub too. It looks mostly the same and it lets you type.

<img width="225" alt="Screenshot 2024-10-08 at 18 58 19" src="https://github.com/user-attachments/assets/cc630c8b-b777-4d54-8fb4-8768e293014e">
<img width="203" alt="Screenshot 2024-10-08 at 18 58 26" src="https://github.com/user-attachments/assets/3a54ef64-0f1b-41e6-9721-c58cab0880dd">

I am also using `fd` so that I don't need to add the themes in the script. I'm just showing the folder name though (`rose-pine` instead of `Rose Pine`). Happy to add it here.

```bash
fd --max-depth 1 . "$OMAKUB_PATH/themes" -X basename {} \;
```


