### PR TITLE
Add emoji extension for Ulauncher

### DIFF
--- a/install/desktop/ulauncher.sh
+++ b/install/desktop/ulauncher.sh
@@ -9,3 +9,6 @@ cp ~/.local/share/omakub/configs/ulauncher.desktop ~/.config/autostart/ulauncher
 gtk-launch ulauncher.desktop >/dev/null 2>&1
 sleep 2 # ensure enough time for ulauncher to set defaults
 cp ~/.local/share/omakub/configs/ulauncher.json ~/.config/ulauncher/settings.json
+
+# Download extensions
+git clone https://github.com/Ulauncher/ulauncher-emoji.git $HOME/.local/share/ulauncher/extensions/com.github.ulauncher.ulauncher-emoji/

--- a/migrations/1729224919.sh
+++ b/migrations/1729224919.sh
@@ -1,0 +1,4 @@
+# Add Ulauncher emoji extension
+if [ ! -d "$HOME/.local/share/ulauncher/extensions/com.github.ulauncher.ulauncher-emoji/" ]; then
+  git clone https://github.com/Ulauncher/ulauncher-emoji.git $HOME/.local/share/ulauncher/extensions/com.github.ulauncher.ulauncher-emoji/
+fi


### PR DESCRIPTION
Issue #251 brought up a good point. I believe we should have an emoji picker since this has been supported on macOS and Windows for some time.

Since we already use Ulauncher, this approach adds an [Emoji extension](https://github.com/Ulauncher/ulauncher-emoji).

A migration has been included to download the extension via update if it doesn't already exist.