### PR TITLE
Update app-steam.sh to install 32bit architecture which steam needs

### DIFF
--- a/install/desktop/optional/app-steam.sh
+++ b/install/desktop/optional/app-steam.sh
@@ -1,5 +1,10 @@
 # Play games from https://store.steampowered.com/
 cd /tmp
+
+sudo dpkg --add-architecture i386
+sudo apt install libgl1-mesa-dri:i386
+sudo apt install libgl1:i386
+
 wget https://cdn.akamai.steamstatic.com/client/installer/steam.deb
 sudo apt install -y ./steam.deb
 rm steam.deb


### PR DESCRIPTION
On my install, steam did not work without these 32 bit libraries. Is this true for everyone? I can't see how it wouldn't be.

If it's something weird with my install only, sorry for wasting time!