### PR TITLE
adjust sleep prevention strategy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,11 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-# Desktop software and tweaks will only be installed if we're running Gnome
-RUNNING_GNOME=$([[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]] && echo true || echo false)
-
 # Check the distribution name and version and abort if incompatible
 source ~/.local/share/omakub/install/check-version.sh
 
-if $RUNNING_GNOME; then
+# Desktop software and tweaks will only be installed if we're running Gnome
+if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]]; then
   # Ensure computer doesn't go to sleep or lock while installing
   gsettings set org.gnome.desktop.screensaver lock-enabled false
   gsettings set org.gnome.desktop.session idle-delay 0
@@ -16,19 +14,17 @@ if $RUNNING_GNOME; then
   source ~/.local/share/omakub/install/terminal/required/app-gum.sh >/dev/null
   source ~/.local/share/omakub/install/first-run-choices.sh
 
-  echo "Installing terminal and desktop tools.."
-else
-  echo "Only installing terminal tools..."
-fi
-
-# Install terminal tools
-source ~/.local/share/omakub/install/terminal.sh
-
-if $RUNNING_GNOME; then
-  # Install desktop tools and tweaks
+  echo "Installing terminal and desktop tools..."
+	# Install terminal tools
+  source ~/.local/share/omakub/install/terminal.sh
+	# Install desktop tools and tweaks
   source ~/.local/share/omakub/install/desktop.sh
 
-  # Revert to normal idle and lock settings
+  # Restore idle and lock settings
   gsettings set org.gnome.desktop.screensaver lock-enabled true
   gsettings set org.gnome.desktop.session idle-delay 300
+else
+  echo "Only installing terminal tools..."
+	# Install terminal tools
+	source ~/.local/share/omakub/install/terminal.sh
 fi

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -1,13 +1,5 @@
-# Ensure computer doesn't go to sleep or lock while installing
-gsettings set org.gnome.desktop.screensaver lock-enabled false
-gsettings set org.gnome.desktop.session idle-delay 0
-
 # Run desktop installers
 for installer in ~/.local/share/omakub/install/desktop/*.sh; do source $installer; done
-
-# Revert to normal idle and lock settings
-gsettings set org.gnome.desktop.screensaver lock-enabled true
-gsettings set org.gnome.desktop.session idle-delay 300
 
 # Logout to pickup changes
 gum confirm "Ready to reboot for all settings to take effect?" && sudo reboot


### PR DESCRIPTION
[REVISED]
Removes redundant idle and lock settings changes from install/desktop.sh and moves the restoring of said settings into install.sh

(Explanation):
install.sh disables sleep by overwriting the session idle delay time and screensaver lock screen settings.
If the desktop environment is Gnome, it calls install/desktop.sh which begins with the exact same lines for disabling sleep.
No other file in the codebase directly calls install/desktop.sh and so there is no reason to repeat these lines - if install/desktop.sh is being ran then sleep will have already be disabled.
However, install/desktop.sh was the only place where those settings were being re-enabled; and since it only gets ran if the desktop environment is Gnome, it made sense just move that part out to install.sh so that both paths (desktop & terminal) could have their settings re-enabled.

Also consolidates the double if conditional and the Gnome check into a single if/else.