### PR TITLE
Extend Workspace Keybindings to Include Workspaces 7, 8, and 9

### DIFF
--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -35,6 +35,9 @@ gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-3 "['<Super>3
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-4 "['<Super>4']"
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5']"
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
+gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>7']"
+gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>8']"
+gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>9']"
 
 # Reserve slots for custom keybindings
 gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']"

--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -35,9 +35,9 @@ gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-3 "['<Super>3
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-4 "['<Super>4']"
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-5 "['<Super>5']"
 gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>6']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>7']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>8']"
-gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-6 "['<Super>9']"
+gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-7 "['<Super>7']"
+gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-8 "['<Super>8']"
+gsettings set org.gnome.desktop.wm.keybindings switch-to-workspace-9 "['<Super>9']"
 
 # Reserve slots for custom keybindings
 gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']"


### PR DESCRIPTION
This PR extends the current workspace keybindings limit, allowing users to switch to workspaces 7, 8, and 9 using `<Super>7`, `<Super>8`, and `<Super>9`.

#### Changes:
- Added keybinding `<Super>7` for switching to workspace 7.
- Added keybinding `<Super>8` for switching to workspace 8.
- Added keybinding `<Super>9` for switching to workspace 9.

#### Motivation:
The existing workspace keybinding setup is limited to workspace 6. By extending the limit to workspace 9, users can better manage multiple tasks without needing to resort to tiling or floating windows. This extension offers an easier way to work across more tasks, improving efficiency and workspace organization.