### PR TITLE
Ulauncher - Change GDK_BACKEND from X11 to wayland

### DIFF
--- a/configs/ulauncher.desktop
+++ b/configs/ulauncher.desktop
@@ -4,7 +4,7 @@ Comment=Application launcher for Linux
 GenericName=Launcher
 Categories=GNOME;GTK;Utility;
 TryExec=/usr/bin/ulauncher
-Exec=env GDK_BACKEND=x11 /usr/bin/ulauncher --hide-window --hide-window
+Exec=env GDK_BACKEND=wayland /usr/bin/ulauncher --hide-window --hide-window
 Icon=ulauncher
 Terminal=false
 Type=Application


### PR DESCRIPTION
On a fresh installation of 24.04, gnome appears to be defaulting to wayland now. ulauncher initially worked (albeit with blurry fonts with fractional scaling), but quickly stopped working for me.

In the desktop file, the GDK_BACKEND was being set to `x11`; changing this `wayland` solved this issue. Not only does it work now, but the fonts are super crisp.

As an aside, searching through the [ulauncher codebase](https://github.com/Ulauncher/Ulauncher/blob/8b19a6094bad5f2b6a424a062f8fc6b903095ca3/ulauncher/utils/launch_detached.py#L50), i see that they set `GDK_BACKEND` to `none` when the env `GDK_BACKEND` is set to _anything other than_ `wayland`, so that may have been the real reason it wouldn't work for me.