### PR TITLE
Drop customization for LazyVim starter config checker

### DIFF
--- a/install/terminal/app-neovim.sh
+++ b/install/terminal/app-neovim.sh
@@ -12,9 +12,6 @@ if [ ! -d "$HOME/.config/nvim" ]; then
 	# Use LazyVim
 	git clone https://github.com/LazyVim/starter ~/.config/nvim
 
-	# Disable update notification popup in starter config
-	sed -i 's/checker = { enabled = true }/checker = { enabled = true, notify = false }/g' ~/.config/nvim/lua/config/lazy.lua
-
 	# Make everything match the terminal transparency
 	mkdir -p ~/.config/nvim/plugin/after
 	cp ~/.local/share/omakub/configs/neovim/transparency.lua ~/.config/nvim/plugin/after/


### PR DESCRIPTION
The default is false now and sed doesn't work/need anymore

Refs: LazyVim/starter/commit/cb6349c
