### PR TITLE
Add Zed theme and font synchronization with Omakub

### DIFF
--- a/bin/omakub-sub/font.sh
+++ b/bin/omakub-sub/font.sh
@@ -19,6 +19,11 @@ set_font() {
 	gsettings set org.gnome.desktop.interface monospace-font-name "$font_name 10"
 	cp "$OMAKUB_PATH/configs/alacritty/fonts/$file_name.toml" ~/.config/alacritty/font.toml
 	sed -i "s/\"editor.fontFamily\": \".*\"/\"editor.fontFamily\": \"$font_name\"/g" ~/.config/Code/User/settings.json
+	if command -v zed &>/dev/null; then
+		ZED_SETTINGS_PATH="$HOME/.config/zed/settings.json"
+		# strip c/c++ like comments from settings.json and set new font
+		cpp -P -E $ZED_SETTINGS_PATH | jq ".buffer_font_family = \"$font_name\"" > temp.json && mv temp.json $ZED_SETTINGS_PATH
+	fi
 }
 
 if [ "$#" -gt 1 ]; then

--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -10,6 +10,7 @@ if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
   source $OMAKUB_PATH/themes/$THEME/gnome.sh
   source $OMAKUB_PATH/themes/$THEME/tophat.sh
   source $OMAKUB_PATH/themes/$THEME/vscode.sh
+  source $OMAKUB_PATH/themes/$THEME/zed.sh
 
   # Forgo setting the Chrome theme until we might find a less disruptive way of doing it.
   # Having to quit Chrome, and all Chrome-based apps, is too much of an inposition.

--- a/install/desktop/optional/app-zed.sh
+++ b/install/desktop/optional/app-zed.sh
@@ -1,1 +1,14 @@
 curl https://zed.dev/install.sh | sh
+
+# zed does not initialize its config directory and settings.json after installation but after first run
+zed
+kill `pidof zed-editor`
+
+ZED_SETTINGS_PATH="$HOME/.config/zed/settings.json"
+# strip c/c++ like comments from settings.json then set  omakub theme and font
+cpp -P -E $ZED_SETTINGS_PATH | jq ".theme = \"Tokyo Night\" | .auto_install_extensions[\"tokyo-night\"] = true | .buffer_font_family = \"CaskaydiaMono Nerd Font\"" > temp.json && mv temp.json $ZED_SETTINGS_PATH
+
+# run zed to install theme
+zed
+sleep 3
+kill `pidof zed-editor`

--- a/themes/catppuccin/zed.sh
+++ b/themes/catppuccin/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Catppuccin Macchiato"
+ZED_EXTENSION="catppuccin"
+source $OMAKUB_PATH/themes/set-zed-theme.sh

--- a/themes/everforest/zed.sh
+++ b/themes/everforest/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Everforest Dark"
+ZED_EXTENSION="everforest"
+source $OMAKUB_PATH/themes/set-zed-theme.sh

--- a/themes/gruvbox/zed.sh
+++ b/themes/gruvbox/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Gruvbox Dark"
+ZED_EXTENSION="gruvbox-material"
+source $OMAKUB_PATH/themes/set-zed-theme.sh

--- a/themes/kanagawa/zed.sh
+++ b/themes/kanagawa/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Kanagawa"
+ZED_EXTENSION="kanagawa-themes"
+source $OMAKUB_PATH/themes/set-zed-theme.sh

--- a/themes/nord/zed.sh
+++ b/themes/nord/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Nord"
+ZED_EXTENSION="nord"
+source $OMAKUB_PATH/themes/set-zed-theme.sh

--- a/themes/rose-pine/zed.sh
+++ b/themes/rose-pine/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Rosé Pine Dawn"
+ZED_EXTENSION="rose-pine-theme"
+source $OMAKUB_PATH/themes/set-zed-theme.sh

--- a/themes/set-zed-theme.sh
+++ b/themes/set-zed-theme.sh
@@ -1,0 +1,6 @@
+# check if zed is installed
+if command -v zed &>/dev/null; then
+    ZED_SETTINGS_PATH="$HOME/.config/zed/settings.json"
+    # strip c/c++ like comments from settings.json and install theme and set it
+    cpp -P -E $ZED_SETTINGS_PATH | jq ".auto_install_extensions[\"$ZED_EXTENSION\"] = true | .theme = \"$ZED_THEME\"" > temp.json && mv temp.json $ZED_SETTINGS_PATH
+fi

--- a/themes/tokyo-night/zed.sh
+++ b/themes/tokyo-night/zed.sh
@@ -1,0 +1,3 @@
+ZED_THEME="Tokyo Night"
+ZED_EXTENSION="tokyo-night"
+source $OMAKUB_PATH/themes/set-zed-theme.sh


### PR DESCRIPTION
This PR enhances Zed code editor with theme and font switching sync and addresses past issue discussion #226 . 

The synchronization  works both for an already installed Zed configuration and for a fresh installation.

### Notice:
Zed installs extensions at runtime and recognizes them at startup. After the first theme switch, Zed might not change theme without restarting application (if the theme was not  installed before). Only _Rose Pine_ works "out of the box", because this theme is a native Zed extension. This also applies to fonts.
