### PR TITLE
Fix shell completion for 'ls' alias by setting '--icons=auto'

### DIFF
--- a/defaults/bash/aliases
+++ b/defaults/bash/aliases
@@ -1,5 +1,5 @@
 # File system
-alias ls='eza -lh --group-directories-first --icons'
+alias ls='eza -lh --group-directories-first --icons=auto'
 alias lsa='ls -a'
 alias lt='eza --tree --level=2 --long --icons --git'
 alias lta='lt -a'


### PR DESCRIPTION
- Updated 'ls' alias to use '--icons=auto' to resolve issue with shell
completions, which previously prompted options instead of completing
filesystem entries.
