### PR TITLE
re-enable hash on last rc script

### DIFF
--- a/defaults/bash/init
+++ b/defaults/bash/init
@@ -10,3 +10,4 @@ if command -v fzf &> /dev/null; then
   source /usr/share/bash-completion/completions/fzf
   source /usr/share/doc/fzf/examples/key-bindings.bash
 fi
+hash -h


### PR DESCRIPTION
The configuration on ` ~/.local/share/omakub/defaults/bash/shell`, sourced by `defaults/bash/rc` disables hash.
The change introduced here re-enables it as part of the last script executed by `rc`.

Fixes #339 

As disclosed at the issue: 
> I'm unfamiliar with the usage of hash within these configuration files, nor do I have a clear idea where a hash -h should be placed to re-enable the command without undoing the intended goal with the disabled. Still, I assume it's a simple fix for whoever has context on its usage.

So please review it carefully as I might be ignoring important  aspects of how this suppose to be used