### PR TITLE
Update Spotify GPG public key

### DIFF
--- a/install/desktop/optional/app-spotify.sh
+++ b/install/desktop/optional/app-spotify.sh
@@ -1,5 +1,5 @@
 # Stream music using https://spotify.com
-curl -sS https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
+curl -sS https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
 echo "deb [signed-by=/etc/apt/trusted.gpg.d/spotify.gpg] http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt update -y
 sudo apt install -y spotify-client


### PR DESCRIPTION
Had some problems verifying the Spotify packages when I was trying out Omakub, turns out that they had updated their public key. 

Got the link to the new pubkey from https://www.spotify.com/en/download/linux/