### PR TITLE
Fix typo in the Zed uninstall script

### DIFF
--- a/uninstall/app-zed.sh
+++ b/uninstall/app-zed.sh
@@ -1,4 +1,4 @@
 rm -rf ~/.local/zed.app
 rm -rf ~/.local/bin/zed
-rm .rf ~/.local/share/applications/dev.zed.Zed.desktop
+rm -rf ~/.local/share/applications/dev.zed.Zed.desktop
 rm -rf ~/.config/zed


### PR DESCRIPTION
Fixes the error `rm: .rf: No such file or directory` when uninstalling Zed. Seems to be only occurrence in the repo.
