### PR TITLE
Add ASDControl to set Apple Studio and XDR display brightness from cli

### DIFF
--- a/bin/omakub-sub/install.sh
+++ b/bin/omakub-sub/install.sh
@@ -1,25 +1,26 @@
 CHOICES=(
-	"Dev Language  Install programming language environment"
-	"Dev Database  Install development database in Docker"
-	"1password     Manage your passwords securely across devices"
-	"Audacity      Record and edit audio"
-	"Brave         Chrome-based browser with built-in ad blocking"
-	"Cursor        The AI Code Editor"
-	"Doom Emacs    Emacs framework with curated list of packages"
-	"Dropbox       Sync files across computers with ease"
-	"OBS Studio    Record screencasts with inputs from both display + webcam"
-	"Ollama        Run LLMs, like Meta's Llama3, locally"
-	"RubyMine      IntelliJ's commercial Ruby editor"
-	"Spotify       Stream music from the world's most popular service"
-	"Steam         Play games from Valve's store"
-	"VirtualBox    Virtual machines to run Windows/Linux"
-	"Zed           Fast all-purpose editor"
-	"Zoom          Attend and host video chat meetings"
-	"> All         Re-run any of the default installers"
-	"<< Back       "
+  "Dev Language  Install programming language environment"
+  "Dev Database  Install development database in Docker"
+  "1password     Manage your passwords securely across devices"
+  "Audacity      Record and edit audio"
+  "ASDControl    Set brightness on Apple Studio and XDR displays via cli"
+  "Brave         Chrome-based browser with built-in ad blocking"
+  "Cursor        The AI Code Editor"
+  "Doom Emacs    Emacs framework with curated list of packages"
+  "Dropbox       Sync files across computers with ease"
+  "OBS Studio    Record screencasts with inputs from both display + webcam"
+  "Ollama        Run LLMs, like Meta's Llama3, locally"
+  "RubyMine      IntelliJ's commercial Ruby editor"
+  "Spotify       Stream music from the world's most popular service"
+  "Steam         Play games from Valve's store"
+  "VirtualBox    Virtual machines to run Windows/Linux"
+  "Zed           Fast all-purpose editor"
+  "Zoom          Attend and host video chat meetings"
+  "> All         Re-run any of the default installers"
+  "<< Back       "
 )
 
-CHOICE=$(gum choose "${CHOICES[@]}" --height 19 --header "Install application")
+CHOICE=$(gum choose "${CHOICES[@]}" --height 20 --header "Install application")
 
 if [[ "$CHOICE" == "<< Back"* ]] || [[ -z "$CHOICE" ]]; then
 	# Don't install anything

--- a/defaults/bash/aliases
+++ b/defaults/bash/aliases
@@ -36,3 +36,14 @@ webm2mp4() {
   output_file="${input_file%.webm}.mp4"
   ffmpeg -i "$input_file" -c:v libx264 -preset slow -crf 22 -c:a aac -b:a 192k "$output_file"
 }
+
+# Allow brightness controls if ASDControl is installed
+if [ -f "/usr/local/bin/asdcontrol" ]; then
+  export APPLE_DISPLAY_DEV=$(asdcontrol --detect /dev/usb/hiddev* | sed -n 's|^\(/dev/usb/hiddev[0-9]*\):.*|\1|p')
+
+  alias brup="asdcontrol $APPLE_DISPLAY_DEV -- +10000"
+  alias brdown="asdcontrol $APPLE_DISPLAY_DEV -- -10000"
+
+  alias brmax="asdcontrol $APPLE_DISPLAY_DEV -- +60000"
+  alias brmin="asdcontrol $APPLE_DISPLAY_DEV -- -60000"
+fi

--- a/defaults/bash/aliases
+++ b/defaults/bash/aliases
@@ -39,7 +39,7 @@ webm2mp4() {
 
 # Allow brightness controls if ASDControl is installed
 if [ -f "/usr/local/bin/asdcontrol" ]; then
-  export APPLE_DISPLAY_DEV=$(asdcontrol --detect /dev/usb/hiddev* | sed -n 's|^\(/dev/usb/hiddev[0-9]*\):.*|\1|p')
+  export APPLE_DISPLAY_DEV=$(asdcontrol --detect /dev/usb/hiddev* 2>/dev/null | sed -n 's|^\(/dev/usb/hiddev[0-9]*\):.*|\1|p')
 
   alias brup="asdcontrol $APPLE_DISPLAY_DEV -- +10000"
   alias brdown="asdcontrol $APPLE_DISPLAY_DEV -- -10000"

--- a/install/desktop/optional/app-asdcontrol.sh
+++ b/install/desktop/optional/app-asdcontrol.sh
@@ -1,0 +1,12 @@
+# Install asdcontrol
+git clone https://github.com/nikosdion/asdcontrol.git /tmp/asdcontrol
+cd /tmp/asdcontrol
+make
+sudo make install
+cd -
+rm -rf /tmp/asdcontrol
+
+# Setup sudo-less controls
+echo 'KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="9243", GROUP="users", OWNER="root", MODE="0660"' | sudo tee /etc/udev/rules.d/50-apple-xdr.rules >/dev/null
+echo 'KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="1114", GROUP="users", OWNER="root", MODE="0660"' | sudo tee /etc/udev/rules.d/50-apple-studio.rules >/dev/null
+sudo udevadm control --reload-rules

--- a/install/desktop/optional/app-asdcontrol.sh
+++ b/install/desktop/optional/app-asdcontrol.sh
@@ -10,3 +10,6 @@ rm -rf /tmp/asdcontrol
 echo 'KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="9243", GROUP="users", OWNER="root", MODE="0660"' | sudo tee /etc/udev/rules.d/50-apple-xdr.rules >/dev/null
 echo 'KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="1114", GROUP="users", OWNER="root", MODE="0660"' | sudo tee /etc/udev/rules.d/50-apple-studio.rules >/dev/null
 sudo udevadm control --reload-rules
+
+# Reboot to pickup changes
+gum confirm "Ready to reboot for brightness controls to be available?" && sudo reboot


### PR DESCRIPTION
Control the brightness of the Apple Studio and Apple XDR displays via the CLI using [asdcontrol](https://github.com/nikosdion/asdcontrol). The following aliases are made available when this optional software is installed:

```
brup # Increase brightness in increment
brdown # Decrease brightness in increment
brmax # Maximum brightness
brmix # Minimum brightness
```