### PR TITLE
Make Alacritty the default terminal emulator

### DIFF
--- a/install/desktop/app-alacritty.sh
+++ b/install/desktop/app-alacritty.sh
@@ -5,3 +5,4 @@ cp ~/.local/share/omakub/configs/alacritty.toml ~/.config/alacritty/alacritty.to
 cp ~/.local/share/omakub/themes/tokyo-night/alacritty.toml ~/.config/alacritty/theme.toml
 cp ~/.local/share/omakub/configs/alacritty/fonts/CaskaydiaMono.toml ~/.config/alacritty/font.toml
 cp ~/.local/share/omakub/configs/alacritty/font-size.toml ~/.config/alacritty/font-size.toml
+sudo update-alternatives --set x-terminal-emulator /usr/bin/alacritty


### PR DESCRIPTION
This makes it work with the "Ctrl + Alt + T" command, as well as any other time a generic terminal emulator is invoked.