### PR TITLE
Replacing to loop and adding focus

### DIFF
--- a/bin/omakub-sub/font-size.sh
+++ b/bin/omakub-sub/font-size.sh
@@ -1,8 +1,10 @@
-choice=$(gum choose {7..14} "<< Back" --height 11 --header "Choose your terminal font size")
+FONT_SIZE_PATH="$HOME/.config/alacritty/font-size.toml"
+choice=$(sed -n "s/^size = \(.*\)$/\1/p" $FONT_SIZE_PATH)
 
-if [[ $choice =~ ^[0-9]+$ ]]; then
-	sed -i "s/^size = .*$/size = $choice/g" ~/.config/alacritty/font-size.toml
-	source $OMAKUB_PATH/bin/omakub-sub/font-size.sh
-else
-	source $OMAKUB_PATH/bin/omakub-sub/font.sh
-fi
+# loop while various font sizes are selected; focus on current font size
+while [[ $choice =~ ^[0-9]+$ ]]; do
+  sed -i "s/^size = .*$/size = $choice/g" $FONT_SIZE_PATH
+  choice=$(gum choose --selected "$choice" {7..14} "<< Back" --height 11 --header "Choose your terminal font size")
+done
+
+source $OMAKUB_PATH/bin/omakub-sub/font.sh

--- a/bin/omakub-sub/uninstall.sh
+++ b/bin/omakub-sub/uninstall.sh
@@ -1,4 +1,9 @@
-UNINSTALLER=$(gum file $OMAKUB_PATH/uninstall --height 26)
-[ -n "$UNINSTALLER" ] && gum confirm "Run uninstaller?" && source $UNINSTALLER && gum spin --spinner globe --title "Uninstall completed!" -- sleep 3
+CHOICES=($(find $OMAKUB_PATH/uninstall -type f -exec basename {} \; | sed 's/app-//;s/\.sh$//' | sort))
+CHOICES+=("<< Back")
+
+choice=$(gum choose "${CHOICES[@]}" --height 29 --header "Uninstall application")
+app_user_wishes_to_uninstall=$(find $OMAKUB_PATH/uninstall -type f -name *"$choice".sh)
+
+[ -n "$app_user_wishes_to_uninstall" ] && gum confirm "Run uninstaller for $choice?" && source $app_user_wishes_to_uninstall && gum spin --spinner globe --title "Uninstall completed!" -- sleep 3
 clear
 source $OMAKUB_PATH/bin/omakub


### PR DESCRIPTION
1. Although the previous solution worked, surrounding with while for readability.
2. Focus ( if that's the name ) :
 - First, reading the exsiting size value from the .toml
 - Then, on load, the focus will be on the configured font size, rather than on the first item. Changing font size will keep the focus on the new value.

* Inside the while, in the first run, the sed will rewrite the existing value; the other approach is to move this line below the choise selection, but then, there's a need to first check that in case of "<<Back" the value won't accidently change the size = << Back in the .toml.
To avoid it, I just moved the sed line above the choice and know that in the first run it will override the same value in the .toml; still looks cleaner than adding an if or a case loop.

Also - kept the same regex; as changing it to something like loop while it's not "<< Back" breaks the ctrl+c , which by default goes to the previous menu. It's possible to add another check for this as well, but it's getting more complex than the existing regex.