### PR TITLE
refactor: replace apt-get with just apt

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -12,8 +12,8 @@ echo -e "$ascii_art"
 echo "=> Omakub is for fresh Ubuntu 24.04+ installations only!"
 echo -e "\nBegin installation (or abort with ctrl+c)..."
 
-sudo apt-get update >/dev/null
-sudo apt-get install -y git >/dev/null
+sudo apt update >/dev/null
+sudo apt install -y git >/dev/null
 
 echo "Cloning Omakub..."
 rm -rf ~/.local/share/omakub

--- a/install/terminal/required/app-gum.sh
+++ b/install/terminal/required/app-gum.sh
@@ -2,6 +2,6 @@
 cd /tmp
 GUM_VERSION="0.14.3" # Use known good version
 wget -qO gum.deb "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_amd64.deb"
-sudo apt-get install -y ./gum.deb
+sudo apt install -y ./gum.deb
 rm gum.deb
 cd -

--- a/uninstall/app-1password.sh
+++ b/uninstall/app-1password.sh
@@ -2,4 +2,4 @@ sudo rm /etc/apt/sources.list.d/1password.list
 sudo rm /usr/share/keyrings/1password-archive-keyring.gpg
 sudo rm /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
 sudo rm -r /etc/debsig/policies/AC2D62742012EA22/
-sudo apt-get remove --purge -y 1password 1password-cli
+sudo apt remove --purge -y 1password 1password-cli


### PR DESCRIPTION
i was exploring why we are running update many places in the code base and noticed we used apt-get in the start but it does not seem required, so proposing to stream line the commands with just one