### PR TITLE
feat: install gum manually with out using apt

### DIFF
--- a/install/terminal/required/app-gum.sh
+++ b/install/terminal/required/app-gum.sh
@@ -1,7 +1,8 @@
 # Gum is used for the Omakub commands for tailoring Omakub after the initial install
 cd /tmp
 GUM_VERSION="0.14.3" # Use known good version
-wget -qO gum.deb "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_amd64.deb"
-sudo apt-get install -y ./gum.deb
-rm gum.deb
+wget -qO gum.tar.gz "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_Linux_x86_64.tar.gz"
+tar -xzvf gum.tar.gz
+sudo cp gum_0.14.3_Linux_x86_64/gum /usr/bin
+rm gum.tar.gz
 cd -


### PR DESCRIPTION
The main benefit of using apt is that you can upgrade etc, but because we are manually fetching the package and pushing it into the install feature, you cant have apt do the upgrades later anyway.

I guess one reason to keep it the way that it is, is if it handles variations in CPU architectures as this package is an x86 binary.

The reason for this change is i am making a fork for fedora and the would like to keep as much of the code the same were possible