### PR TITLE
fix: curl unzip are used in desktop as well

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -12,8 +12,10 @@ echo -e "$ascii_art"
 echo "=> Omakub is for fresh Ubuntu 24.04+ installations only!"
 echo -e "\nBegin installation (or abort with ctrl+c)..."
 
-sudo apt update >/dev/null
-sudo apt install -y git >/dev/null
+sudo apt update > /dev/null
+sudo apt upgrade -y > /dev/null
+sudo apt install -y curl git unzip >/dev/null
+
 
 echo "Cloning Omakub..."
 rm -rf ~/.local/share/omakub

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -1,7 +1,2 @@
-# Needed for all installers
-sudo apt update -y
-sudo apt upgrade -y
-sudo apt install -y curl git unzip
-
 # Run terminal installers
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done


### PR DESCRIPTION
currently the curl and unzip packages are installed in terminal.sh, but they are used in desktop installers as well, so i combined them with the git as a dependency of the entire script. 
I noticed that we did `sudo apt upgrade -y` in terminal.sh, so moved that as well

![image](https://github.com/user-attachments/assets/31afe63e-5b64-4820-b768-b11ac1da4c94)
![image](https://github.com/user-attachments/assets/38b31518-0b1e-4cb2-99a6-a647c6792228)


Turns out that unzip is only used in desktop but installed in terminal.sh, if i searched correctly :)

