### PR TITLE
Add Mainline Kernels as optional install

### DIFF
--- a/bin/omakub-sub/install.sh
+++ b/bin/omakub-sub/install.sh
@@ -1,26 +1,27 @@
 CHOICES=(
-  "Dev Language  Install programming language environment"
-  "Dev Database  Install development database in Docker"
-  "1password     Manage your passwords securely across devices"
-  "Audacity      Record and edit audio"
-  "ASDControl    Set brightness on Apple Studio and XDR displays via cli"
-  "Brave         Chrome-based browser with built-in ad blocking"
-  "Cursor        The AI Code Editor"
-  "Doom Emacs    Emacs framework with curated list of packages"
-  "Dropbox       Sync files across computers with ease"
-  "OBS Studio    Record screencasts with inputs from both display + webcam"
-  "Ollama        Run LLMs, like Meta's Llama3, locally"
-  "RubyMine      IntelliJ's commercial Ruby editor"
-  "Spotify       Stream music from the world's most popular service"
-  "Steam         Play games from Valve's store"
-  "VirtualBox    Virtual machines to run Windows/Linux"
-  "Zed           Fast all-purpose editor"
-  "Zoom          Attend and host video chat meetings"
-  "> All         Re-run any of the default installers"
-  "<< Back       "
+  "Dev Language      Install programming language environment"
+  "Dev Database      Install development database in Docker"
+  "1password         Manage your passwords securely across devices"
+  "Audacity          Record and edit audio"
+  "ASDControl        Set brightness on Apple Studio and XDR displays via cli"
+  "Brave             Chrome-based browser with built-in ad blocking"
+  "Cursor            The AI Code Editor"
+  "Doom Emacs        Emacs framework with curated list of packages"
+  "Dropbox           Sync files across computers with ease"
+  "Mainline Kernels  Install newer Linux kernels than Ubuntu defaults"
+  "OBS Studio        Record screencasts with inputs from both display + webcam"
+  "Ollama            Run LLMs, like Meta's Llama3, locally"
+  "RubyMine          IntelliJ's commercial Ruby editor"
+  "Spotify           Stream music from the world's most popular service"
+  "Steam             Play games from Valve's store"
+  "VirtualBox        Virtual machines to run Windows/Linux"
+  "Zed               Fast all-purpose editor"
+  "Zoom              Attend and host video chat meetings"
+  "> All             Re-run any of the default installers"
+  "<< Back           "
 )
 
-CHOICE=$(gum choose "${CHOICES[@]}" --height 21 --header "Install application")
+CHOICE=$(gum choose "${CHOICES[@]}" --height 22 --header "Install application")
 
 if [[ "$CHOICE" == "<< Back"* ]] || [[ -z "$CHOICE" ]]; then
   # Don't install anything

--- a/install/terminal/optional/app-mainline-kernels.sh
+++ b/install/terminal/optional/app-mainline-kernels.sh
@@ -1,0 +1,3 @@
+sudo add-apt-repository ppa:cappelikan/ppa
+sudo apt update -y
+sudo apt install -y mainline

--- a/uninstall/app-mainline-kernels.sh
+++ b/uninstall/app-mainline-kernels.sh
@@ -1,0 +1,1 @@
+sudo apt remove -y mainline


### PR DESCRIPTION
This is currently helpful especially for newer AMD CPUs that require 6.13+ for correct scheduling while Ubuntu 24.04 ships with 6.11.