### PR TITLE
Only run against modified shell files

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,7 +1,3 @@
-name: ShellCheck
-
-on: [push, pull_request]
-
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
@@ -13,11 +9,5 @@ jobs:
     - name: Install ShellCheck
       run: sudo apt-get install -y shellcheck
 
-    - name: Check for modified shell files and run ShellCheck
-      run: |
-        MODIFIED_FILES=$(git diff --name-only origin/master HEAD | grep -E '\.sh$' || true)
-        if [ -n "$MODIFIED_FILES" ]; then
-          echo "$MODIFIED_FILES" | xargs shellcheck
-        else
-          echo "No modified shell files to check."
-        fi
+    - name: Run ShellCheck
+      run: shellcheck $(awk -F'=' '/^source=/{print $2}' .shellcheckrc)

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,10 +15,9 @@ jobs:
 
     - name: Check for modified shell files and run ShellCheck
       run: |
-        MODIFIED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E '\.sh$' || true)
+        MODIFIED_FILES=$(git diff --name-only origin/main HEAD | grep -E '\.sh$' || true)
         if [ -n "$MODIFIED_FILES" ]; then
           echo "$MODIFIED_FILES" | xargs shellcheck
         else
           echo "No modified shell files to check."
         fi
-

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,24 @@
+name: ShellCheck
+
+on: [push, pull_request]
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Install ShellCheck
+      run: sudo apt-get install -y shellcheck
+
+    - name: Check for modified shell files and run ShellCheck
+      run: |
+        MODIFIED_FILES=$(git diff --name-only HEAD^ HEAD | grep -E '\.sh$' || true)
+        if [ -n "$MODIFIED_FILES" ]; then
+          echo "$MODIFIED_FILES" | xargs shellcheck
+        else
+          echo "No modified shell files to check."
+        fi
+

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Check for modified shell files and run ShellCheck
       run: |
-        MODIFIED_FILES=$(git diff --name-only origin/main HEAD | grep -E '\.sh$' || true)
+        MODIFIED_FILES=$(git diff --name-only origin/master HEAD | grep -E '\.sh$' || true)
         if [ -n "$MODIFIED_FILES" ]; then
           echo "$MODIFIED_FILES" | xargs shellcheck
         else

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,3 +1,4 @@
+on: [push]
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,1 +1,2 @@
+source=dev-mode.sh
 source=update_shellcheckrc.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,2 +1,3 @@
 source=dev-mode.sh
+source=install/terminal.sh
 source=update_shellcheckrc.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+source=install/terminal.sh
+source=update_shellcheckrc.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,2 +1,1 @@
-source=install/terminal.sh
 source=update_shellcheckrc.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,2 @@
 source=dev-mode.sh
-source=install/terminal.sh
 source=update_shellcheckrc.sh

--- a/dev-mode.sh
+++ b/dev-mode.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+touch ./.git/hooks/pre-commit
+
+chmod +x ./.git/hooks/pre-commit
+
+echo "#!/bin/bash" >./.git/hooks/pre-commit
+echo "bash ./update_shellcheckrc.sh" >>./.git/hooks/pre-commit

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,5 +3,5 @@ sudo apt update -y
 sudo apt upgrade -y
 sudo apt install -y curl git unzip
 
-# Run terminal installers
+# Run terminal installers modified
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,5 +3,5 @@ sudo apt update -y
 sudo apt upgrade -y
 sudo apt install -y curl git unzip
 
-# Run terminal installers
+# Run terminal each installer
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,5 +3,5 @@ sudo apt update -y
 sudo apt upgrade -y
 sudo apt install -y curl git unzip
 
-# Run terminal installers modified
+# Run terminal installers
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done

--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,5 +3,5 @@ sudo apt update -y
 sudo apt upgrade -y
 sudo apt install -y curl git unzip
 
-# Run terminal each installer
+# Run terminal installers
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done

--- a/update_shellcheckrc.sh
+++ b/update_shellcheckrc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Get the list of modified shell files
+MODIFIED_FILES=$(git diff --name-only master | grep -E '\.sh$' || true)
+
+# Update the .shellcheckrc file
+if [ -n "$MODIFIED_FILES" ]; then
+  # Remove previous entries
+  sed -i '/^source=.*$/d' .shellcheckrc
+  for file in $MODIFIED_FILES; do
+    echo "source=$file" >>.shellcheckrc
+  done
+
+  # Add .shellcheckrc to the staging
+  git add .shellcheckrc
+  git commit -m "Add modified shell files to the shellcheck action"
+  git push
+else
+  echo "No modified shell files to check."
+fi

--- a/update_shellcheckrc.sh
+++ b/update_shellcheckrc.sh
@@ -16,5 +16,3 @@ if [ -n "$MODIFIED_FILES" ]; then
 else
   echo "No modified shell files to check."
 fi
-
-chmod +x .git/hooks/pre-push

--- a/update_shellcheckrc.sh
+++ b/update_shellcheckrc.sh
@@ -13,7 +13,8 @@ if [ -n "$MODIFIED_FILES" ]; then
   # Add .shellcheckrc to the staging
   git add .shellcheckrc
   git commit -m "Add modified shell files to the shellcheck action"
-  git push
 else
   echo "No modified shell files to check."
 fi
+
+chmod +x .git/hooks/pre-push

--- a/update_shellcheckrc.sh
+++ b/update_shellcheckrc.sh
@@ -11,8 +11,8 @@ if [ -n "$MODIFIED_FILES" ]; then
   done
 
   # Add .shellcheckrc to the staging
+  echo "Adding .shellcheck to the staging."
   git add .shellcheckrc
-  git commit -m "Add modified shell files to the shellcheck action"
 else
   echo "No modified shell files to check."
 fi


### PR DESCRIPTION
Based in #70 and inspired in @anavarre suggestion, only run shellcheck against modified files. 
Developers are free to add they own modified files to the `.shellcheckrc` list, which is considered in the CI. However, by running `./dev-mode`, a pre-commit is created and update the shellcheck list automatically.

By running shellcheck only against modified files is a way to balance inheritance and code quality in the long run.