### PR TITLE
Prevent Alacritty from closing on Zellij session detach

### DIFF
--- a/defaults/alacritty.toml
+++ b/defaults/alacritty.toml
@@ -2,7 +2,8 @@
 TERM = "xterm-256color"
 
 [shell]
-program = "zellij"
+program = "/bin/bash"
+args = ["-c", "zellij; exec bash"]
 
 [window]
 padding.x = 16


### PR DESCRIPTION
Closes #420 

This tweak still launches Zellij automatically in Alacritty, but it won’t auto-close if you detach. Instead Zellij is launched through bash, so when you detach, you drop back into the shell instead of losing the whole terminal. Now after you restart your computer, you can re-attach to your previous Zellij session.