### PR TITLE
Explicitly set accent color in theme

### DIFF
--- a/themes/set-gnome-theme.sh
+++ b/themes/set-gnome-theme.sh
@@ -2,6 +2,7 @@ gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
 gsettings set org.gnome.desktop.interface cursor-theme 'Yaru'
 gsettings set org.gnome.desktop.interface gtk-theme "Yaru-$OMAKUB_THEME_COLOR-dark"
 gsettings set org.gnome.desktop.interface icon-theme "Yaru-$OMAKUB_THEME_COLOR"
+gsettings set org.gnome.desktop.interface accent-color "$OMAKUB_THEME_COLOR"
 
 BACKGROUND_ORG_PATH="$HOME/.local/share/omakub/themes/$OMAKUB_THEME_BACKGROUND"
 BACKGROUND_DEST_DIR="$HOME/.local/share/backgrounds"


### PR DESCRIPTION
The accent color does not get automatically set in Ubuntu 25.04 when the GTK Theme is set.