### PR TITLE
fix fzf: No such file or directory after upgrade to Plucky Pufin

### DIFF
--- a/defaults/bash/init
+++ b/defaults/bash/init
@@ -7,6 +7,10 @@ if command -v zoxide &> /dev/null; then
 fi
 
 if command -v fzf &> /dev/null; then
-  source /usr/share/bash-completion/completions/fzf
-  source /usr/share/doc/fzf/examples/key-bindings.bash
+  if [[ -f /usr/share/bash-completion/completions/fzf ]]; then
+    source /usr/share/bash-completion/completions/fzf
+  fi
+  if [[ -f /usr/share/doc/fzf/examples/key-bindings.bash ]]; then
+    source /usr/share/doc/fzf/examples/key-bindings.bash
+  fi
 fi


### PR DESCRIPTION
Related to https://github.com/basecamp/omakub/issues/426