### PR TITLE
Allow enabling the LazyVIM extras module when installing languages

### DIFF
--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -6,6 +6,18 @@ else
   languages=$(gum choose "${AVAILABLE_LANGUAGES[@]}" --no-limit --height 10 --header "Select programming languages to uninstall")
 fi
 
+disable_lazyvim_extras() {
+  local config_file="$HOME/.config/nvim/lazyvim.json"
+  local extras=("$@")
+
+  local extras_json
+  extras_json=$(printf '"%s",' "${extras[@]}")
+  extras_json="[${extras_json%,}]"
+
+  # This is cheating to mimic an in-place editing of files (without a tmp file)...
+  { rm "$config_file" && jq --argjson extras "$extras_json" '.extras |= (. - $extras)' >"$config_file"; } <"$config_file"
+}
+
 if [[ -n $languages ]]; then
   for language in $languages; do
     case $language in
@@ -15,14 +27,17 @@ if [[ -n $languages ]]; then
       ;;
     Node.js)
       mise uninstall node@lts
+      disable_lazyvim_extras "lazyvim.plugins.extras.lang.typescript"
       ;;
     Go)
       mise uninstall go@latest
+      disable_lazyvim_extras "lazyvim.plugins.extras.lang.go"
       ;;
     PHP)
       sudo apt -y purge php8.4 php8.4-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
       sudo add-apt-repository -y --remove ppa:ondrej/php
       sudo rm /usr/local/bin/composer
+      disable_lazyvim_extras "lazyvim.plugins.extras.lang.php"
       ;;
     Python)
       mise uninstall python@latest


### PR DESCRIPTION
### Changed

- Another attempt at dynamically enabling the extra modules per-language when installing (see https://github.com/basecamp/omakub/pull/269). This will create the `lazyvim.json` when it doesn't exist and add the language modules (if confirmed).
- It also removes the extra modules when uninstalling the languages

---

This needs https://github.com/LazyVim/LazyVim/pull/5941 to be merged and tagged in LazyVIM. The migration script is currently messing up the modules when it starts for the first time.