### PR TITLE
Make Alacritty configs compatible with v15+

### DIFF
--- a/applications/About.sh
+++ b/applications/About.sh
@@ -3,7 +3,7 @@ cat <<EOF >~/.local/share/applications/About.desktop
 Version=1.0
 Name=About
 Comment=System information from Fastfetch
-Exec=alacritty --config-file /home/$USER/.local/share/omakub/defaults/alacritty/pane.toml --class=About --title=About -e bash -c 'fastfetch; read -n 1 -s'
+Exec=alacritty --config-file /home/$USER/.config/alacritty/pane.toml --class=About --title=About -e bash -c 'fastfetch; read -n 1 -s'
 Terminal=false
 Type=Application
 Icon=/home/$USER/.local/share/omakub/applications/icons/Ubuntu.png

--- a/applications/Activity.sh
+++ b/applications/Activity.sh
@@ -3,7 +3,7 @@ cat <<EOF >~/.local/share/applications/Activity.desktop
 Version=1.0
 Name=Activity
 Comment=System activity from btop
-Exec=alacritty --config-file /home/$USER/.local/share/omakub/defaults/alacritty/btop.toml --class=Activity --title=Activity -e btop
+Exec=alacritty --config-file /home/$USER/.config/alacritty/btop.toml --class=Activity --title=Activity -e btop
 Terminal=false
 Type=Application
 Icon=/home/$USER/.local/share/omakub/applications/icons/Activity.png

--- a/applications/Docker.sh
+++ b/applications/Docker.sh
@@ -3,7 +3,7 @@ cat <<EOF >~/.local/share/applications/Docker.desktop
 Version=1.0
 Name=Docker
 Comment=Manage Docker containers with LazyDocker
-Exec=alacritty --config-file /home/$USER/.local/share/omakub/defaults/alacritty/pane.toml --class=Docker --title=Docker -e lazydocker
+Exec=alacritty --config-file /home/$USER/.config/alacritty/pane.toml --class=Docker --title=Docker -e lazydocker
 Terminal=false
 Type=Application
 Icon=/home/$USER/.local/share/omakub/applications/icons/Docker.png

--- a/applications/Neovim.sh
+++ b/applications/Neovim.sh
@@ -3,7 +3,7 @@ cat <<EOF >~/.local/share/applications/Neovim.desktop
 Version=1.0
 Name=Neovim
 Comment=Edit text files
-Exec=alacritty --config-file /home/$USER/.local/share/omakub/defaults/alacritty/pane.toml --class=Neovim --title=Neovim -e nvim %F
+Exec=alacritty --config-file /home/$USER/.config/alacritty/pane.toml --class=Neovim --title=Neovim -e nvim %F
 Terminal=false
 Type=Application
 Icon=nvim

--- a/applications/Omakub.sh
+++ b/applications/Omakub.sh
@@ -3,7 +3,7 @@ cat <<EOF >~/.local/share/applications/Omakub.desktop
 Version=1.0
 Name=Omakub
 Comment=Omakub Controls
-Exec=alacritty --config-file /home/$USER/.local/share/omakub/defaults/alacritty/pane.toml --class=Omakub --title=Omakub -e omakub
+Exec=alacritty --config-file /home/$USER/.config/alacritty/pane.toml --class=Omakub --title=Omakub -e omakub
 Terminal=false
 Type=Application
 Icon=/home/$USER/.local/share/omakub/applications/icons/Omakub.png

--- a/configs/alacritty/btop.toml
+++ b/configs/alacritty/btop.toml
@@ -1,4 +1,5 @@
-import = [ "~/.local/share/omakub/defaults/alacritty/pane.toml" ]
+# Used by the Activity.desktop app
+import = [ "~/.config/alacritty/pane.toml" ]
 
 [window]
 dimensions.columns = 121

--- a/configs/alacritty/pane.toml
+++ b/configs/alacritty/pane.toml
@@ -1,5 +1,7 @@
+# Used by the About.desktop, Activity.desktop, Docker.desktop, Omakub.desktop, and Neovim.desktop apps
 import = [ "~/.config/alacritty/theme.toml", "~/.config/alacritty/font.toml", "~/.config/alacritty/font-size.toml", "~/.local/share/omakub/defaults/alacritty.toml" ]
 
 [window]
 padding.x = 30
 padding.y = 30
+

--- a/defaults/alacritty/omakub.toml
+++ b/defaults/alacritty/omakub.toml
@@ -1,5 +1,0 @@
-import = [ "~/.local/share/omakub/defaults/alacritty/pane.toml" ]
-
-[window]
-dimensions.columns = 90
-dimensions.lines = 30

--- a/install/desktop/app-alacritty.sh
+++ b/install/desktop/app-alacritty.sh
@@ -2,11 +2,15 @@
 sudo apt install -y alacritty
 mkdir -p ~/.config/alacritty
 cp ~/.local/share/omakub/configs/alacritty.toml ~/.config/alacritty/alacritty.toml
+cp ~/.local/share/omakub/configs/alacritty/pane.toml ~/.config/alacritty/pane.toml
+cp ~/.local/share/omakub/configs/alacritty/btop.toml ~/.config/alacritty/btop.toml
 cp ~/.local/share/omakub/themes/tokyo-night/alacritty.toml ~/.config/alacritty/theme.toml
 cp ~/.local/share/omakub/configs/alacritty/fonts/CaskaydiaMono.toml ~/.config/alacritty/font.toml
 cp ~/.local/share/omakub/configs/alacritty/font-size.toml ~/.config/alacritty/font-size.toml
 
 # Migrate config format if needed
 alacritty migrate 2>/dev/null
+alacritty migrate --config-file=~/.config/alacritty/pane.toml 2>/dev/null
+alacritty migrate --config-file=~/.config/alacritty/btop.toml 2>/dev/null
 
 source $OMAKUB_PATH/install/desktop/set-alacritty-default.sh

--- a/migrations/1745060743.sh
+++ b/migrations/1745060743.sh
@@ -1,0 +1,12 @@
+cp ~/.local/share/omakub/configs/alacritty/pane.toml ~/.config/alacritty/pane.toml
+cp ~/.local/share/omakub/configs/alacritty/btop.toml ~/.config/alacritty/btop.toml
+
+source $OMAKUB_PATH/applications/About.sh
+source $OMAKUB_PATH/applications/Activity.sh
+source $OMAKUB_PATH/applications/Neovim.sh
+source $OMAKUB_PATH/applications/Docker.sh
+source $OMAKUB_PATH/applications/Omakub.sh
+
+alacritty migrate 2>/dev/null
+alacritty migrate --config-file=~/.config/alacritty/pane.toml 2>/dev/null
+alacritty migrate --config-file=~/.config/alacritty/btop.toml 2>/dev/null


### PR DESCRIPTION
Requires making the sub configs explicit so we can run alacritty migrate to upgrade them after v15.