### PR TITLE
app-gum.sh fails to install on retry

### DIFF
--- a/install/terminal/required/app-gum.sh
+++ b/install/terminal/required/app-gum.sh
@@ -2,6 +2,6 @@
 cd /tmp
 GUM_VERSION="0.14.3" # Use known good version
 wget -qO gum.deb "https://github.com/charmbracelet/gum/releases/download/v${GUM_VERSION}/gum_${GUM_VERSION}_amd64.deb"
-sudo apt-get install -y ./gum.deb
+sudo apt-get install -y --allow-downgrades ./gum.deb
 rm gum.deb
 cd -


### PR DESCRIPTION
**Change:**
add --allow-downgrades to the app-gum.sh install script, allowing retries to succeed.

**Details:**
My internet died during Omakub's install, causing a timeout during one of the package installs. 
Re-running the install then gives this error consistently:

**E: Packages were downgraded and -y was used without --allow-downgrades.**

I added --allow-downgrades to the apt line in app-gum.sh, which resolved the issue for me. 
Bit of an edge case, but don't see the harm in changing this.

![image](https://github.com/user-attachments/assets/5e08300b-d3a9-4d0b-b1f6-c5e3de1b6810)