### PR TITLE
Improved nvim checks

### DIFF
--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -5,7 +5,9 @@ if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
   cp $OMAKUB_PATH/themes/$THEME/alacritty.toml ~/.config/alacritty/theme.toml
   cp $OMAKUB_PATH/themes/$THEME/zellij.kdl ~/.config/zellij/themes/$THEME.kdl
   sed -i "s/theme \".*\"/theme \"$THEME\"/g" ~/.config/zellij/config.kdl
-  cp $OMAKUB_PATH/themes/$THEME/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
+  if [ -d "$HOME/.config/nvim" ]; then
+    cp $OMAKUB_PATH/themes/$THEME/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
+  fi
 
   source $OMAKUB_PATH/themes/$THEME/gnome.sh
   source $OMAKUB_PATH/themes/$THEME/tophat.sh

--- a/install/terminal/app-neovim.sh
+++ b/install/terminal/app-neovim.sh
@@ -34,5 +34,6 @@ fi
 # Replace desktop launcher with one running inside Alacritty
 if [[ -d ~/.local/share/applications ]]; then
   sudo rm -rf /usr/share/applications/nvim.desktop
+  sudo rm -rf /usr/local/share/applications/nvim.desktop
   source ~/.local/share/omakub/applications/Neovim.sh
 fi


### PR DESCRIPTION
I noticed that when I update nvim from Omakub TUI it still regenerates the desktop app from the package.
I think it's okay to remove it.

Also, I only update the nvim theme if it is actually installed.

This PR implements #443  and improves the git history.
