### PR TITLE
Updated Zellij themes with new specs

### DIFF
--- a/migrations/1746707329.sh
+++ b/migrations/1746707329.sh
@@ -1,0 +1,17 @@
+# Overwrite old zellij themes with new ones
+if [ -d ~/.config/zellij/themes ]; then
+    files=()
+    for file in ~/.config/zellij/themes/*.kdl; do
+        if [[ -f "$file" ]]; then
+            files+=("$file")
+        fi
+    done
+
+    if [ ${#files[@]} -gt 0 ]; then
+        for file in "${files[@]}"; do
+            if [ -d "$OMAKUB_PATH/themes/$(basename "$file" .kdl)" ]; then
+                cp "$OMAKUB_PATH/themes/$(basename "$file" .kdl)"/zellij.kdl ~/.config/zellij/themes/$(basename "$file" .kdl).kdl
+            fi
+        done
+    fi
+fi

--- a/themes/catppuccin/zellij.kdl
+++ b/themes/catppuccin/zellij.kdl
@@ -1,57 +1,120 @@
 themes {
-  catppuccin {
-    bg "#626880" // Surface2
-    fg "#c6d0f5"
-    red "#e78284"
-    green "#a6d189"
-    blue "#8caaee"
-    yellow "#e5c890"
-    magenta "#f4b8e4" // Pink
-    orange "#ef9f76" // Peach
-    cyan "#99d1db" // Sky
-    black "#292c3c" // Mantle
-    white "#c6d0f5"
-  }
-
-  catppuccin-latte {
-    bg "#acb0be" // Surface2
-    fg "#acb0be" // Surface2
-    red "#d20f39"
-    green "#40a02b"
-    blue "#1e66f5"
-    yellow "#df8e1d"
-    magenta "#ea76cb" // Pink
-    orange "#fe640b" // Peach
-    cyan "#04a5e5" // Sky
-    black "#dce0e8" // Crust
-    white "#4c4f69" // Text
-  }
-
-  catppuccin-macchiato {
-    bg "#5b6078" // Surface2
-    fg "#cad3f5"
-    red "#ed8796"
-    green "#a6da95"
-    blue "#8aadf4"
-    yellow "#eed49f"
-    magenta "#f5bde6" // Pink
-    orange "#f5a97f" // Peach
-    cyan "#91d7e3" // Sky
-    black "#1e2030" // Mantle
-    white "#cad3f5"
-  }
-
-  catppuccin-mocha {
-    bg "#585b70" // Surface2
-    fg "#cdd6f4"
-    red "#f38ba8"
-    green "#a6e3a1"
-    blue "#89b4fa"
-    yellow "#f9e2af"
-    magenta "#f5c2e7" // Pink
-    orange "#fab387" // Peach
-    cyan "#89dceb" // Sky
-    black "#181825" // Mantle
-    white "#cdd6f4"
-  }
+    catppuccin {
+        text_unselected {
+            base 198 208 245
+            background 41 44 60
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        text_selected {
+            base 198 208 245
+            background 98 104 128
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        ribbon_selected {
+            base 41 44 60
+            background 166 209 137
+            emphasis_0 231 130 132
+            emphasis_1 239 159 118
+            emphasis_2 244 184 228
+            emphasis_3 140 170 238
+        }
+        ribbon_unselected {
+            base 41 44 60
+            background 198 208 245
+            emphasis_0 231 130 132
+            emphasis_1 198 208 245
+            emphasis_2 140 170 238
+            emphasis_3 244 184 228
+        }
+        table_title {
+            base 166 209 137
+            background 0
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        table_cell_selected {
+            base 198 208 245
+            background 98 104 128
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        table_cell_unselected {
+            base 198 208 245
+            background 41 44 60
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        list_selected {
+            base 198 208 245
+            background 98 104 128
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        list_unselected {
+            base 198 208 245
+            background 41 44 60
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 166 209 137
+            emphasis_3 244 184 228
+        }
+        frame_selected {
+            base 166 209 137
+            background 0
+            emphasis_0 239 159 118
+            emphasis_1 153 209 219
+            emphasis_2 244 184 228
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 239 159 118
+            background 0
+            emphasis_0 244 184 228
+            emphasis_1 239 159 118
+            emphasis_2 239 159 118
+            emphasis_3 239 159 118
+        }
+        exit_code_success {
+            base 166 209 137
+            background 0
+            emphasis_0 153 209 219
+            emphasis_1 41 44 60
+            emphasis_2 244 184 228
+            emphasis_3 140 170 238
+        }
+        exit_code_error {
+            base 231 130 132
+            background 0
+            emphasis_0 229 200 144
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 244 184 228
+            player_2 140 170 238
+            player_3 0
+            player_4 229 200 144
+            player_5 153 209 219
+            player_6 0
+            player_7 231 130 132
+            player_8 0
+            player_9 0
+            player_10 0
+        }
+    }
 }

--- a/themes/everforest/zellij.kdl
+++ b/themes/everforest/zellij.kdl
@@ -1,15 +1,120 @@
 themes {
     everforest {
-        bg "#2b3339"
-        fg "#d3c6aa"
-        black "#4b565c"
-        red "#e67e80"
-        green "#a7c080"
-        yellow "#dbbc7f"
-        blue "#7fbbb3"
-        magenta "#d699b6"
-        cyan "#83c092"
-        white "#d3c6aa"
-        orange "#FF9E64"
+        text_unselected {
+            base 211 198 170
+            background 75 86 92
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        text_selected {
+            base 75 86 92
+            background 131 192 146
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        ribbon_selected {
+            base 75 86 92
+            background 167 192 128
+            emphasis_0 230 126 128
+            emphasis_1 255 158 100
+            emphasis_2 214 153 182
+            emphasis_3 127 187 179
+        }
+        ribbon_unselected {
+            base 75 86 92
+            background 211 198 170
+            emphasis_0 230 126 128
+            emphasis_1 211 198 170
+            emphasis_2 127 187 179
+            emphasis_3 214 153 182
+        }
+        table_title {
+            base 167 192 128
+            background 0
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        table_cell_selected {
+            base 75 86 92
+            background 131 192 146
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        table_cell_unselected {
+            base 211 198 170
+            background 75 86 92
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        list_selected {
+            base 75 86 92
+            background 131 192 146
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        list_unselected {
+            base 211 198 170
+            background 75 86 92
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 167 192 128
+            emphasis_3 214 153 182
+        }
+        frame_selected {
+            base 167 192 128
+            background 0
+            emphasis_0 255 158 100
+            emphasis_1 131 192 146
+            emphasis_2 214 153 182
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 255 158 100
+            background 0
+            emphasis_0 214 153 182
+            emphasis_1 255 158 100
+            emphasis_2 255 158 100
+            emphasis_3 255 158 100
+        }
+        exit_code_success {
+            base 167 192 128
+            background 0
+            emphasis_0 131 192 146
+            emphasis_1 75 86 92
+            emphasis_2 214 153 182
+            emphasis_3 127 187 179
+        }
+        exit_code_error {
+            base 230 126 128
+            background 0
+            emphasis_0 219 188 127
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 214 153 182
+            player_2 127 187 179
+            player_3 0
+            player_4 219 188 127
+            player_5 131 192 146
+            player_6 0
+            player_7 230 126 128
+            player_8 0
+            player_9 0
+            player_10 0
+        }
     }
 }

--- a/themes/gruvbox/zellij.kdl
+++ b/themes/gruvbox/zellij.kdl
@@ -1,15 +1,120 @@
 themes {
-    gruvbox {
-        fg "#d5c4a1"
-        bg "#282828"
-        black "#3c3836"
-        red "#cc241d"
-        green "#98971a"
-        yellow "#d79921"
-        blue "#3c8588"
-        magenta "#b16286"
-        cyan "#689d6a"
-        white "#fbf1c7"
-        orange "#d65d0e"
+    gruvbox-dark {
+        text_unselected {
+            base 251 241 199
+            background 60 56 54
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        text_selected {
+            base 251 241 199
+            background 80 73 69
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        ribbon_selected {
+            base 60 56 54
+            background 152 151 26
+            emphasis_0 204 36 29
+            emphasis_1 214 93 14
+            emphasis_2 177 98 134
+            emphasis_3 69 133 136
+        }
+        ribbon_unselected {
+            base 60 56 54
+            background 235 219 178
+            emphasis_0 204 36 29
+            emphasis_1 251 241 199
+            emphasis_2 69 133 136
+            emphasis_3 177 98 134
+        }
+        table_title {
+            base 152 151 26
+            background 0
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        table_cell_selected {
+            base 251 241 199
+            background 80 73 69
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        table_cell_unselected {
+            base 251 241 199
+            background 60 56 54
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        list_selected {
+            base 251 241 199
+            background 80 73 69
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        list_unselected {
+            base 251 241 199
+            background 60 56 54
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 152 151 26
+            emphasis_3 177 98 134
+        }
+        frame_selected {
+            base 152 151 26
+            background 0
+            emphasis_0 214 93 14
+            emphasis_1 104 157 106
+            emphasis_2 177 98 134
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 214 93 14
+            background 0
+            emphasis_0 177 98 134
+            emphasis_1 214 93 14
+            emphasis_2 214 93 14
+            emphasis_3 214 93 14
+        }
+        exit_code_success {
+            base 152 151 26
+            background 0
+            emphasis_0 104 157 106
+            emphasis_1 60 56 54
+            emphasis_2 177 98 134
+            emphasis_3 69 133 136
+        }
+        exit_code_error {
+            base 204 36 29
+            background 0
+            emphasis_0 215 153 33
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 177 98 134
+            player_2 69 133 136
+            player_3 0
+            player_4 215 153 33
+            player_5 104 157 106
+            player_6 0
+            player_7 204 36 29
+            player_8 0
+            player_9 0
+            player_10 0
+        }
     }
 }

--- a/themes/kanagawa/zellij.kdl
+++ b/themes/kanagawa/zellij.kdl
@@ -1,15 +1,120 @@
 themes {
     kanagawa {
-        fg "#DCD7BA"
-        bg "#1F1F28"
-        red "#C34043"
-        green "#76946A"
-        yellow "#FF9E3B"
-        blue "#7E9CD8"
-        magenta "#957FB8"
-        orange "#FFA066"
-        cyan "#7FB4CA"
-        black "#16161D"
-        white "#DCD7BA"
+        text_unselected {
+            base 220 215 186
+            background 22 22 29
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        text_selected {
+            base 22 22 29
+            background 118 148 106
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        ribbon_selected {
+            base 22 22 29
+            background 118 148 106
+            emphasis_0 195 64 67
+            emphasis_1 255 160 102
+            emphasis_2 149 127 184
+            emphasis_3 126 156 216
+        }
+        ribbon_unselected {
+            base 22 22 29
+            background 220 215 186
+            emphasis_0 195 64 67
+            emphasis_1 220 215 186
+            emphasis_2 126 156 216
+            emphasis_3 149 127 184
+        }
+        table_title {
+            base 118 148 106
+            background 0
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        table_cell_selected {
+            base 22 22 29
+            background 118 148 106
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        table_cell_unselected {
+            base 220 215 186
+            background 22 22 29
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        list_selected {
+            base 22 22 29
+            background 118 148 106
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        list_unselected {
+            base 220 215 186
+            background 22 22 29
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 118 148 106
+            emphasis_3 149 127 184
+        }
+        frame_selected {
+            base 118 148 106
+            background 0
+            emphasis_0 255 160 102
+            emphasis_1 127 180 202
+            emphasis_2 149 127 184
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 255 160 102
+            background 0
+            emphasis_0 149 127 184
+            emphasis_1 255 160 102
+            emphasis_2 255 160 102
+            emphasis_3 255 160 102
+        }
+        exit_code_success {
+            base 118 148 106
+            background 0
+            emphasis_0 127 180 202
+            emphasis_1 22 22 29
+            emphasis_2 149 127 184
+            emphasis_3 126 156 216
+        }
+        exit_code_error {
+            base 195 64 67
+            background 0
+            emphasis_0 255 158 59
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 149 127 184
+            player_2 126 156 216
+            player_3 0
+            player_4 255 158 59
+            player_5 127 180 202
+            player_6 0
+            player_7 195 64 67
+            player_8 0
+            player_9 0
+            player_10 0
+        }
     }
 }

--- a/themes/nord/zellij.kdl
+++ b/themes/nord/zellij.kdl
@@ -1,15 +1,120 @@
 themes {
     nord {
-        fg "#D8DEE9"
-        bg "#2E3440"
-        black "#3B4252"
-        red "#BF616A"
-        green "#A3BE8C"
-        yellow "#EBCB8B"
-        blue "#81A1C1"
-        magenta "#B48EAD"
-        cyan "#88C0D0"
-        white "#E5E9F0"
-        orange "#D08770"
+        text_unselected {
+            base 229 233 240
+            background 59 66 82
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        text_selected {
+            base 229 233 240
+            background 59 66 82
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        ribbon_selected {
+            base 59 66 82
+            background 163 190 140
+            emphasis_0 191 97 106
+            emphasis_1 208 135 112
+            emphasis_2 180 142 173
+            emphasis_3 129 161 193
+        }
+        ribbon_unselected {
+            base 59 66 82
+            background 216 222 233
+            emphasis_0 191 97 106
+            emphasis_1 229 233 240
+            emphasis_2 129 161 193
+            emphasis_3 180 142 173
+        }
+        table_title {
+            base 163 190 140
+            background 0
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        table_cell_selected {
+            base 229 233 240
+            background 46 52 64
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        table_cell_unselected {
+            base 229 233 240
+            background 59 66 82
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        list_selected {
+            base 229 233 240
+            background 46 52 64
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        list_unselected {
+            base 229 233 240
+            background 59 66 82
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 163 190 140
+            emphasis_3 180 142 173
+        }
+        frame_selected {
+            base 163 190 140
+            background 0
+            emphasis_0 208 135 112
+            emphasis_1 136 192 208
+            emphasis_2 180 142 173
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 208 135 112
+            background 0
+            emphasis_0 180 142 173
+            emphasis_1 208 135 112
+            emphasis_2 208 135 112
+            emphasis_3 208 135 112
+        }
+        exit_code_success {
+            base 163 190 140
+            background 0
+            emphasis_0 136 192 208
+            emphasis_1 59 66 82
+            emphasis_2 180 142 173
+            emphasis_3 129 161 193
+        }
+        exit_code_error {
+            base 191 97 106
+            background 0
+            emphasis_0 235 203 139
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 180 142 173
+            player_2 129 161 193
+            player_3 0
+            player_4 235 203 139
+            player_5 136 192 208
+            player_6 0
+            player_7 191 97 106
+            player_8 0
+            player_9 0
+            player_10 0
+        }
     }
 }

--- a/themes/rose-pine/zellij.kdl
+++ b/themes/rose-pine/zellij.kdl
@@ -1,15 +1,120 @@
 themes {
-	rose-pine {
-		bg "#faf4ed"
-		fg "#575279"
-		red "#b4637a"
-		green "#286983"
-		blue "#56949f"
-		yellow "#ea9d34"
-		magenta "#907aa9"
-		orange "#fe640b"
-		cyan "#d7827e"
-		black "#f2e9e1"
-		white "#575279"
-	}
+		rose-pine {
+        text_unselected {
+            base 87 82 121
+            background 244 237 232
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        text_selected {
+            base 87 82 121
+            background 223 218 217
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        ribbon_selected {
+            base 244 237 232
+            background 40 105 131
+            emphasis_0 234 157 52
+            emphasis_1 215 130 126
+            emphasis_2 144 122 169
+            emphasis_3 86 148 159
+        }
+        ribbon_unselected {
+            base 250 244 237
+            background 87 82 121
+            emphasis_0 234 157 52
+            emphasis_1 215 130 126
+            emphasis_2 144 122 169
+            emphasis_3 86 148 159
+        }
+        table_title {
+            base 40 105 131
+            background 0 0 0
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        table_cell_selected {
+            base 87 82 121
+            background 223 218 217
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        table_cell_unselected {
+            base 87 82 121
+            background 244 237 232
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        list_selected {
+            base 87 82 121
+            background 223 218 217
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        list_unselected {
+            base 87 82 121
+            background 244 237 232
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 40 105 131
+            emphasis_3 144 122 169
+        }
+        frame_selected {
+            base 40 105 131
+            background 0 0 0
+            emphasis_0 215 130 126
+            emphasis_1 86 148 159
+            emphasis_2 144 122 169
+            emphasis_3 0 0 0
+        }
+        frame_highlight {
+            base 215 130 126
+            background 0 0 0
+            emphasis_0 215 130 126
+            emphasis_1 215 130 126
+            emphasis_2 215 130 126
+            emphasis_3 215 130 126
+        }
+        exit_code_success {
+            base 40 105 131
+            background 0 0 0
+            emphasis_0 86 148 159
+            emphasis_1 244 237 232
+            emphasis_2 144 122 169
+            emphasis_3 40 105 131
+        }
+        exit_code_error {
+            base 180 99 122
+            background 0 0 0
+            emphasis_0 234 157 52
+            emphasis_1 0 0 0
+            emphasis_2 0 0 0
+            emphasis_3 0 0 0
+        }
+        multiplayer_user_colors {
+            player_1 144 122 169
+            player_2 40 105 131
+            player_3 215 130 126
+            player_4 234 157 52
+            player_5 86 148 159
+            player_6 180 99 122
+            player_7 0 0 0
+            player_8 0 0 0
+            player_9 0 0 0
+            player_10 0 0 0
+        }
+		}
 }

--- a/themes/tokyo-night/zellij.kdl
+++ b/themes/tokyo-night/zellij.kdl
@@ -1,15 +1,120 @@
 themes {
     tokyo-night {
-        fg 169 177 214
-        bg 26 27 38
-        black 56 62 90
-        red 249 51 87
-        green 158 206 106
-        yellow 224 175 104
-        blue 122 162 247
-        magenta 187 154 247
-        cyan 42 195 222
-        white 192 202 245
-        orange 255 158 100
+        text_unselected {
+            base 192 202 245
+            background 56 62 90
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        text_selected {
+            base 192 202 245
+            background 56 62 90
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        ribbon_selected {
+            base 56 62 90
+            background 158 206 106
+            emphasis_0 249 51 87
+            emphasis_1 255 158 100
+            emphasis_2 187 154 247
+            emphasis_3 122 162 247
+        }
+        ribbon_unselected {
+            base 56 62 90
+            background 169 177 214
+            emphasis_0 249 51 87
+            emphasis_1 192 202 245
+            emphasis_2 122 162 247
+            emphasis_3 187 154 247
+        }
+        table_title {
+            base 158 206 106
+            background 0
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        table_cell_selected {
+            base 192 202 245
+            background 56 62 90
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        table_cell_unselected {
+            base 192 202 245
+            background 56 62 90
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        list_selected {
+            base 192 202 245
+            background 56 62 90
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        list_unselected {
+            base 192 202 245
+            background 56 62 90
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 158 206 106
+            emphasis_3 187 154 247
+        }
+        frame_selected {
+            base 158 206 106
+            background 0
+            emphasis_0 255 158 100
+            emphasis_1 42 195 222
+            emphasis_2 187 154 247
+            emphasis_3 0
+        }
+        frame_highlight {
+            base 255 158 100
+            background 0
+            emphasis_0 187 154 247
+            emphasis_1 255 158 100
+            emphasis_2 255 158 100
+            emphasis_3 255 158 100
+        }
+        exit_code_success {
+            base 158 206 106
+            background 0
+            emphasis_0 42 195 222
+            emphasis_1 56 62 90
+            emphasis_2 187 154 247
+            emphasis_3 122 162 247
+        }
+        exit_code_error {
+            base 249 51 87
+            background 0
+            emphasis_0 224 175 104
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 0
+        }
+        multiplayer_user_colors {
+            player_1 187 154 247
+            player_2 122 162 247
+            player_3 0
+            player_4 224 175 104
+            player_5 42 195 222
+            player_6 0
+            player_7 249 51 87
+            player_8 0
+            player_9 0
+            player_10 0
+        }
     }
 }


### PR DESCRIPTION
This update is based on [this issue](https://github.com/basecamp/omakub/issues/450) which reports that text highlighting with the mouse no longer appears in the terminal.

Checking the [Zellij documentation](https://zellij.dev/documentation/themes.html) they changed the specs for the themes and those in the previous format are considered [_legacy_](https://zellij.dev/documentation/legacy-themes.html) although they are still supported.

I then proceeded with the alignment and then provided a migration script.

I found all the [themes](https://github.com/zellij-org/zellij/tree/main/zellij-utils/assets/themes) in the Zellij repository, instead for `rose-pine` I relied on [this repository](https://github.com/rose-pine/zellij) and specifically on [this PR](https://github.com/rose-pine/zellij/pull/5), with the update already.