### PR TITLE
Update Btop/Activity theme

### DIFF
--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -7,6 +7,13 @@ if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
   sed -i "s/theme \".*\"/theme \"$THEME\"/g" ~/.config/zellij/config.kdl
   cp $OMAKUB_PATH/themes/$THEME/neovim.lua ~/.config/nvim/lua/plugins/theme.lua
 
+  if [ -f "$OMAKUB_PATH/themes/$THEME/btop.theme" ]; then
+    cp $OMAKUB_PATH/themes/$THEME/btop.theme ~/.config/btop/themes/$THEME.theme
+    sed -i "s/color_theme = \".*\"/color_theme = \"$THEME\"/g" ~/.config/btop/btop.conf
+  else
+    sed -i "s/color_theme = \".*\"/color_theme = \"Default\"/g" ~/.config/btop/btop.conf
+  fi
+
   source $OMAKUB_PATH/themes/$THEME/gnome.sh
   source $OMAKUB_PATH/themes/$THEME/tophat.sh
   source $OMAKUB_PATH/themes/$THEME/vscode.sh

--- a/configs/alacritty/btop.toml
+++ b/configs/alacritty/btop.toml
@@ -4,8 +4,3 @@ import = [ "~/.config/alacritty/pane.toml" ]
 [window]
 dimensions.columns = 121
 dimensions.lines = 40
-
-[colors]
-[colors.primary]
-foreground = '#ffffff'
-background = '#000000'

--- a/configs/btop.conf
+++ b/configs/btop.conf
@@ -1,0 +1,245 @@
+#? Config file for btop v. 1.3.0
+
+#* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
+#* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
+color_theme = "Default"
+
+#* If the theme set background should be shown, set to False if you want terminal background transparency.
+theme_background = True
+
+#* Sets if 24-bit truecolor should be used, will convert 24-bit colors to 256 color (6x6x6 color cube) if false.
+truecolor = True
+
+#* Set to true to force tty mode regardless if a real tty has been detected or not.
+#* Will force 16-color mode and TTY theme, set all graph symbols to "tty" and swap out other non tty friendly symbols.
+force_tty = False
+
+#* Define presets for the layout of the boxes. Preset 0 is always all boxes shown with default settings. Max 9 presets.
+#* Format: "box_name:P:G,box_name:P:G" P=(0 or 1) for alternate positions, G=graph symbol to use for box.
+#* Use whitespace " " as separator between different presets.
+#* Example: "cpu:0:default,mem:0:tty,proc:1:default cpu:0:braille,proc:0:tty"
+presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:default cpu:0:block,net:0:tty"
+
+#* Set to True to enable "h,j,k,l,g,G" keys for directional control in lists.
+#* Conflicting keys for h:"help" and k:"kill" is accessible while holding shift.
+vim_keys = False
+
+#* Rounded corners on boxes, is ignored if TTY mode is ON.
+rounded_corners = True
+
+#* Default symbols to use for graph creation, "braille", "block" or "tty".
+#* "braille" offers the highest resolution but might not be included in all fonts.
+#* "block" has half the resolution of braille but uses more common characters.
+#* "tty" uses only 3 different symbols but will work with most fonts and should work in a real TTY.
+#* Note that "tty" only has half the horizontal resolution of the other two, so will show a shorter historical view.
+graph_symbol = "braille"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_cpu = "default"
+
+# Graph symbol to use for graphs in gpu box, "default", "braille", "block" or "tty".
+graph_symbol_gpu = "default"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_mem = "default"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_net = "default"
+
+# Graph symbol to use for graphs in cpu box, "default", "braille", "block" or "tty".
+graph_symbol_proc = "default"
+
+#* Manually set which boxes to show. Available values are "cpu mem net proc" and "gpu0" through "gpu5", separate values with whitespace.
+shown_boxes = "cpu mem net proc"
+
+#* Update time in milliseconds, recommended 2000 ms or above for better sample times for graphs.
+update_ms = 2000
+
+#* Processes sorting, "pid" "program" "arguments" "threads" "user" "memory" "cpu lazy" "cpu direct",
+#* "cpu lazy" sorts top process over time (easier to follow), "cpu direct" updates top process directly.
+proc_sorting = "cpu lazy"
+
+#* Reverse sorting order, True or False.
+proc_reversed = False
+
+#* Show processes as a tree.
+proc_tree = False
+
+#* Use the cpu graph colors in the process list.
+proc_colors = True
+
+#* Use a darkening gradient in the process list.
+proc_gradient = True
+
+#* If process cpu usage should be of the core it's running on or usage of the total available cpu power.
+proc_per_core = False
+
+#* Show process memory as bytes instead of percent.
+proc_mem_bytes = True
+
+#* Show cpu graph for each process.
+proc_cpu_graphs = True
+
+#* Use /proc/[pid]/smaps for memory information in the process info box (very slow but more accurate)
+proc_info_smaps = False
+
+#* Show proc box on left side of screen instead of right.
+proc_left = False
+
+#* (Linux) Filter processes tied to the Linux kernel(similar behavior to htop).
+proc_filter_kernel = False
+
+#* In tree-view, always accumulate child process resources in the parent process.
+proc_aggregate = False
+
+#* Sets the CPU stat shown in upper half of the CPU graph, "total" is always available.
+#* Select from a list of detected attributes from the options menu.
+cpu_graph_upper = "Auto"
+
+#* Sets the CPU stat shown in lower half of the CPU graph, "total" is always available.
+#* Select from a list of detected attributes from the options menu.
+cpu_graph_lower = "Auto"
+
+#* If gpu info should be shown in the cpu box. Available values = "Auto", "On" and "Off".
+show_gpu_info = "Auto"
+
+#* Toggles if the lower CPU graph should be inverted.
+cpu_invert_lower = True
+
+#* Set to True to completely disable the lower CPU graph.
+cpu_single_graph = False
+
+#* Show cpu box at bottom of screen instead of top.
+cpu_bottom = False
+
+#* Shows the system uptime in the CPU box.
+show_uptime = True
+
+#* Show cpu temperature.
+check_temp = True
+
+#* Which sensor to use for cpu temperature, use options menu to select from list of available sensors.
+cpu_sensor = "Auto"
+
+#* Show temperatures for cpu cores also if check_temp is True and sensors has been found.
+show_coretemp = True
+
+#* Set a custom mapping between core and coretemp, can be needed on certain cpus to get correct temperature for correct core.
+#* Use lm-sensors or similar to see which cores are reporting temperatures on your machine.
+#* Format "x:y" x=core with wrong temp, y=core with correct temp, use space as separator between multiple entries.
+#* Example: "4:0 5:1 6:3"
+cpu_core_map = ""
+
+#* Which temperature scale to use, available values: "celsius", "fahrenheit", "kelvin" and "rankine".
+temp_scale = "celsius"
+
+#* Use base 10 for bits/bytes sizes, KB = 1000 instead of KiB = 1024.
+base_10_sizes = False
+
+#* Show CPU frequency.
+show_cpu_freq = True
+
+#* Draw a clock at top of screen, formatting according to strftime, empty string to disable.
+#* Special formatting: /host = hostname | /user = username | /uptime = system uptime
+clock_format = "%X"
+
+#* Update main ui in background when menus are showing, set this to false if the menus is flickering too much for comfort.
+background_update = True
+
+#* Custom cpu model name, empty string to disable.
+custom_cpu_name = ""
+
+#* Optional filter for shown disks, should be full path of a mountpoint, separate multiple values with whitespace " ".
+#* Begin line with "exclude=" to change to exclude filter, otherwise defaults to "most include" filter. Example: disks_filter="exclude=/boot /home/user".
+disks_filter = ""
+
+#* Show graphs instead of meters for memory values.
+mem_graphs = True
+
+#* Show mem box below net box instead of above.
+mem_below_net = False
+
+#* Count ZFS ARC in cached and available memory.
+zfs_arc_cached = True
+
+#* If swap memory should be shown in memory box.
+show_swap = True
+
+#* Show swap as a disk, ignores show_swap value above, inserts itself after first disk.
+swap_disk = True
+
+#* If mem box should be split to also show disks info.
+show_disks = True
+
+#* Filter out non physical disks. Set this to False to include network disks, RAM disks and similar.
+only_physical = True
+
+#* Read disks list from /etc/fstab. This also disables only_physical.
+use_fstab = True
+
+#* Setting this to True will hide all datasets, and only show ZFS pools. (IO stats will be calculated per-pool)
+zfs_hide_datasets = False
+
+#* Set to true to show available disk space for privileged users.
+disk_free_priv = False
+
+#* Toggles if io activity % (disk busy time) should be shown in regular disk usage view.
+show_io_stat = True
+
+#* Toggles io mode for disks, showing big graphs for disk read/write speeds.
+io_mode = False
+
+#* Set to True to show combined read/write io graphs in io mode.
+io_graph_combined = False
+
+#* Set the top speed for the io graphs in MiB/s (100 by default), use format "mountpoint:speed" separate disks with whitespace " ".
+#* Example: "/mnt/media:100 /:20 /boot:1".
+io_graph_speeds = ""
+
+#* Set fixed values for network graphs in Mebibits. Is only used if net_auto is also set to False.
+net_download = 100
+
+net_upload = 100
+
+#* Use network graphs auto rescaling mode, ignores any values set above and rescales down to 10 Kibibytes at the lowest.
+net_auto = True
+
+#* Sync the auto scaling for download and upload to whichever currently has the highest scale.
+net_sync = True
+
+#* Starts with the Network Interface specified here.
+net_iface = ""
+
+#* Show battery stats in top right if battery is present.
+show_battery = True
+
+#* Which battery to use if multiple are present. "Auto" for auto detection.
+selected_battery = "Auto"
+
+#* Set loglevel for "~/.config/btop/btop.log" levels are: "ERROR" "WARNING" "INFO" "DEBUG".
+#* The level set includes all lower levels, i.e. "DEBUG" will show all logging info.
+log_level = "WARNING"
+
+#* Measure PCIe throughput on NVIDIA cards, may impact performance on certain cards.
+nvml_measure_pcie_speeds = True
+
+#* Horizontally mirror the GPU graph.
+gpu_mirror_graph = True
+
+#* Custom gpu0 model name, empty string to disable.
+custom_gpu_name0 = ""
+
+#* Custom gpu1 model name, empty string to disable.
+custom_gpu_name1 = ""
+
+#* Custom gpu2 model name, empty string to disable.
+custom_gpu_name2 = ""
+
+#* Custom gpu3 model name, empty string to disable.
+custom_gpu_name3 = ""
+
+#* Custom gpu4 model name, empty string to disable.
+custom_gpu_name4 = ""
+
+#* Custom gpu5 model name, empty string to disable.
+custom_gpu_name5 = ""

--- a/install/terminal/app-btop.sh
+++ b/install/terminal/app-btop.sh
@@ -1,0 +1,9 @@
+# This script installs btop, a resource monitor that shows usage and stats for processor, memory, disks, network and processes.
+sudo apt install -y btop
+
+# Only attempt to set configuration if btop is not already set
+if [ ! -f "$HOME/.config/btop/btop.conf" ]; then
+  # Use Omakub btop config
+  mkdir -p ~/.config/btop
+  cp ~/.local/share/omakub/configs/btop.conf ~/.config/btop/btop.conf
+fi

--- a/install/terminal/apps-terminal.sh
+++ b/install/terminal/apps-terminal.sh
@@ -1,1 +1,1 @@
-sudo apt install -y fzf ripgrep bat eza zoxide plocate btop apache2-utils fd-find tldr
+sudo apt install -y fzf ripgrep bat eza zoxide plocate apache2-utils fd-find tldr

--- a/migrations/1747237126.sh
+++ b/migrations/1747237126.sh
@@ -1,5 +1,13 @@
 cp ~/.local/share/omakub/configs/alacritty/btop.toml ~/.config/alacritty/btop.toml
 
+# Only attempt to set configuration if btop is not already set
+if [ ! -f "$HOME/.config/btop/btop.conf" ]; then
+  # Use Omakub btop config
+  mkdir -p ~/.config/btop
+  cp ~/.local/share/omakub/configs/btop.conf ~/.config/btop/btop.conf
+fi
+
+# Set the theme for btop
 THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa" "Rose Pine")
 THEME=$(gum choose "${THEME_NAMES[@]}" ">> Skip" --header "Choose your current theme" --height 10 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
 

--- a/migrations/1747237126.sh
+++ b/migrations/1747237126.sh
@@ -1,0 +1,13 @@
+cp ~/.local/share/omakub/configs/alacritty/btop.toml ~/.config/alacritty/btop.toml
+
+THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa" "Rose Pine")
+THEME=$(gum choose "${THEME_NAMES[@]}" ">> Skip" --header "Choose your current theme" --height 10 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
+
+if [ -n "$THEME" ] && [ "$THEME" != ">>-skip" ]; then
+  if [ -f "$OMAKUB_PATH/themes/$THEME/btop.theme" ]; then
+    cp $OMAKUB_PATH/themes/$THEME/btop.theme ~/.config/btop/themes/$THEME.theme
+    sed -i "s/color_theme = \".*\"/color_theme = \"$THEME\"/g" ~/.config/btop/btop.conf
+  else
+    sed -i "s/color_theme = \".*\"/color_theme = \"Default\"/g" ~/.config/btop/btop.conf
+  fi
+fi

--- a/themes/catppuccin/btop.theme
+++ b/themes/catppuccin/btop.theme
@@ -1,0 +1,83 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#303446"
+
+# Main text color
+theme[main_fg]="#c6d0f5"
+
+# Title color for boxes
+theme[title]="#c6d0f5"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#8caaee"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#51576d"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#8caaee"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#838ba7"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#f2d5cf"
+
+# Background color of the percentage meters
+theme[meter_bg]="#51576d"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#f2d5cf"
+
+# CPU, Memory, Network, Proc box outline colors
+theme[cpu_box]="#ca9ee6" #Mauve
+theme[mem_box]="#a6d189" #Green
+theme[net_box]="#ea999c" #Maroon
+theme[proc_box]="#8caaee" #Blue
+
+# Box divider line and small boxes line color
+theme[div_line]="#737994"
+
+# Temperature graph color (Green -> Yellow -> Red)
+theme[temp_start]="#a6d189"
+theme[temp_mid]="#e5c890"
+theme[temp_end]="#e78284"
+
+# CPU graph colors (Teal -> Lavender)
+theme[cpu_start]="#81c8be"
+theme[cpu_mid]="#85c1dc"
+theme[cpu_end]="#babbf1"
+
+# Mem/Disk free meter (Mauve -> Lavender -> Blue)
+theme[free_start]="#ca9ee6"
+theme[free_mid]="#babbf1"
+theme[free_end]="#8caaee"
+
+# Mem/Disk cached meter (Sapphire -> Lavender)
+theme[cached_start]="#85c1dc"
+theme[cached_mid]="#8caaee"
+theme[cached_end]="#babbf1"
+
+# Mem/Disk available meter (Peach -> Red)
+theme[available_start]="#ef9f76"
+theme[available_mid]="#ea999c"
+theme[available_end]="#e78284"
+
+# Mem/Disk used meter (Green -> Sky)
+theme[used_start]="#a6d189"
+theme[used_mid]="#81c8be"
+theme[used_end]="#99d1db"
+
+# Download graph colors (Peach -> Red)
+theme[download_start]="#ef9f76"
+theme[download_mid]="#ea999c"
+theme[download_end]="#e78284"
+
+# Upload graph colors (Green -> Sky)
+theme[upload_start]="#a6d189"
+theme[upload_mid]="#81c8be"
+theme[upload_end]="#99d1db"
+
+# Process box color gradient for threads, mem and cpu usage (Sapphire -> Mauve)
+theme[process_start]="#85c1dc"
+theme[process_mid]="#babbf1"
+theme[process_end]="#ca9ee6"

--- a/themes/everforest/btop.theme
+++ b/themes/everforest/btop.theme
@@ -1,0 +1,92 @@
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#2d353b"
+
+# Main text color
+theme[main_fg]="#d3c6aa"
+
+# Title color for boxes
+theme[title]="#d3c6aa"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#e67e80"
+
+# Background color of selected items
+theme[selected_bg]="#3d484d"
+
+# Foreground color of selected items
+theme[selected_fg]="#dbbc7f"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#2d353b"  
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#d3c6aa"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#a7c080"
+
+# Cpu box outline color
+theme[cpu_box]="#3d484d"
+
+# Memory/disks box outline color
+theme[mem_box]="#3d484d"
+
+# Net up/down box outline color
+theme[net_box]="#3d484d"
+
+# Processes box outline color
+theme[proc_box]="#3d484d"
+
+# Box divider line and small boxes line color
+theme[div_line]="#3d484d"
+
+# Temperature graph colors
+theme[temp_start]="#a7c080"
+theme[temp_mid]="#dbbc7f"
+theme[temp_end]="#f85552"
+
+# CPU graph colors
+theme[cpu_start]="#a7c080"
+theme[cpu_mid]="#dbbc7f"
+theme[cpu_end]="#f85552"
+
+# Mem/Disk free meter
+theme[free_start]="#f85552"
+theme[free_mid]="#dbbc7f"
+theme[free_end]="#a7c080"
+
+# Mem/Disk cached meter
+theme[cached_start]="#7fbbb3"
+theme[cached_mid]="#83c092"
+theme[cached_end]="#a7c080"
+
+# Mem/Disk available meter
+theme[available_start]="#f85552"
+theme[available_mid]="#dbbc7f"
+theme[available_end]="#a7c080"
+
+# Mem/Disk used meter
+theme[used_start]="#a7c080"
+theme[used_mid]="#dbbc7f"
+theme[used_end]="#f85552"
+
+# Download graph colors
+theme[download_start]="#a7c080"
+theme[download_mid]="#83c092"
+theme[download_end]="#7fbbb3"
+
+# Upload graph colors
+theme[upload_start]="#dbbc7f"
+theme[upload_mid]="#e69875"
+theme[upload_end]="#e67e80"
+
+# Process box color gradient for threads, mem and cpu usage
+theme[process_start]="#a7c080"
+theme[process_mid]="#e67e80"
+theme[process_end]="#f85552"
+

--- a/themes/gruvbox/btop.theme
+++ b/themes/gruvbox/btop.theme
@@ -1,0 +1,92 @@
+#Bashtop gruvbox (https://github.com/morhetz/gruvbox) theme
+#by BachoSeven
+
+# Colors should be in 6 or 2 character hexadecimal or single spaced rgb decimal: "#RRGGBB", "#BW" or "0-255 0-255 0-255"
+# example for white: "#FFFFFF", "#ff" or "255 255 255".
+
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#1d2021"
+
+# Main text color
+theme[main_fg]="#a89984"
+
+# Title color for boxes
+theme[title]="#ebdbb2"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#d79921"
+
+# Background color of selected items
+theme[selected_bg]="#282828"
+
+# Foreground color of selected items
+theme[selected_fg]="#fabd2f"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#282828"
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#585858"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#98971a"
+
+# Cpu box outline color
+theme[cpu_box]="#a89984"
+
+# Memory/disks box outline color
+theme[mem_box]="#a89984"
+
+# Net up/down box outline color
+theme[net_box]="#a89984"
+
+# Processes box outline color
+theme[proc_box]="#a89984"
+
+# Box divider line and small boxes line color
+theme[div_line]="#a89984"
+
+# Temperature graph colors
+theme[temp_start]="#458588"
+theme[temp_mid]="#d3869b"
+theme[temp_end]="#fb4394"
+
+# CPU graph colors
+theme[cpu_start]="#b8bb26"
+theme[cpu_mid]="#d79921"
+theme[cpu_end]="#fb4934"
+
+# Mem/Disk free meter
+theme[free_start]="#4e5900"
+theme[free_mid]=""
+theme[free_end]="#98971a"
+
+# Mem/Disk cached meter
+theme[cached_start]="#458588"
+theme[cached_mid]=""
+theme[cached_end]="#83a598"
+
+# Mem/Disk available meter
+theme[available_start]="#d79921"
+theme[available_mid]=""
+theme[available_end]="#fabd2f"
+
+# Mem/Disk used meter
+theme[used_start]="#cc241d"
+theme[used_mid]=""
+theme[used_end]="#fb4934"
+
+# Download graph colors
+theme[download_start]="#3d4070"
+theme[download_mid]="#6c71c4"
+theme[download_end]="#a3a8f7"
+
+# Upload graph colors
+theme[upload_start]="#701c45"
+theme[upload_mid]="#b16286"
+theme[upload_end]="#d3869b"

--- a/themes/kanagawa/btop.theme
+++ b/themes/kanagawa/btop.theme
@@ -1,0 +1,86 @@
+# Bashtop Kanagawa-wave (https://github.com/rebelot/kanagawa.nvim) theme
+# By: philikarus
+
+# Main bg
+theme[main_bg]="#16161D"
+
+# Main text color
+theme[main_fg]="#dcd7ba"
+
+# Title color for boxes
+theme[title]="#dcd7ba"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#C34043"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#223249"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#dca561"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#727169"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#7aa89f"
+
+# Cpu box outline color
+theme[cpu_box]="#727169"
+
+# Memory/disks box outline color
+theme[mem_box]="#727169"
+
+# Net up/down box outline color
+theme[net_box]="#727169"
+
+# Processes box outline color
+theme[proc_box]="#727169"
+
+# Box divider line and small boxes line color
+theme[div_line]="#727169"
+
+# Temperature graph colors
+theme[temp_start]="#98BB6C"
+theme[temp_mid]="#DCA561"
+theme[temp_end]="#E82424"
+
+# CPU graph colors
+theme[cpu_start]="#98BB6C"
+theme[cpu_mid]="#DCA561"
+theme[cpu_end]="#E82424"
+
+# Mem/Disk free meter
+theme[free_start]="#E82424"
+theme[free_mid]="#C34043"
+theme[free_end]="#FF5D62"
+
+# Mem/Disk cached meter
+theme[cached_start]="#C0A36E"
+theme[cached_mid]="#DCA561"
+theme[cached_end]="#FF9E3B"
+
+# Mem/Disk available meter
+theme[available_start]="#938AA9"
+theme[available_mid]="#957FBB"
+theme[available_end]="#9CABCA"
+
+# Mem/Disk used meter
+theme[used_start]="#658594"
+theme[used_mid]="#7E9CDB"
+theme[used_end]="#7FB4CA"
+
+# Download graph colors
+theme[download_start]="#7E9CDB"
+theme[download_mid]="#938AA9"
+theme[download_end]="#957FBB"
+
+# Upload graph colors
+theme[upload_start]="#DCA561"
+theme[upload_mid]="#E6C384"
+theme[upload_end]="#E82424"
+
+# Process box color gradient for threads, mem and cpu usage
+theme[process_start]="#98BB6C"
+theme[process_mid]="#DCA561"
+theme[process_end]="#C34043"

--- a/themes/nord/btop.theme
+++ b/themes/nord/btop.theme
@@ -1,0 +1,89 @@
+#Bashtop theme with nord palette (https://www.nordtheme.com)
+#by Justin Zobel <justin.zobel@gmail.com>
+
+# Colors should be in 6 or 2 character hexadecimal or single spaced rgb decimal: "#RRGGBB", "#BW" or "0-255 0-255 0-255"
+# example for white: "#ffffff", "#ff" or "255 255 255".
+
+# All graphs and meters can be gradients
+# For single color graphs leave "mid" and "end" variable empty.
+# Use "start" and "end" variables for two color gradient
+# Use "start", "mid" and "end" for three color gradient
+
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#2E3440"
+
+# Main text color
+theme[main_fg]="#D8DEE9"
+
+# Title color for boxes
+theme[title]="#8FBCBB"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#5E81AC"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#4C566A"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#ECEFF4"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#4C566A"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#5E81AC"
+
+# Cpu box outline color
+theme[cpu_box]="#4C566A"
+
+# Memory/disks box outline color
+theme[mem_box]="#4C566A"
+
+# Net up/down box outline color
+theme[net_box]="#4C566A"
+
+# Processes box outline color
+theme[proc_box]="#4C566A"
+
+# Box divider line and small boxes line color
+theme[div_line]="#4C566A"
+
+# Temperature graph colors
+theme[temp_start]="#81A1C1"
+theme[temp_mid]="#88C0D0"
+theme[temp_end]="#ECEFF4"
+
+# CPU graph colors
+theme[cpu_start]="#81A1C1"
+theme[cpu_mid]="#88C0D0"
+theme[cpu_end]="#ECEFF4"
+
+# Mem/Disk free meter
+theme[free_start]="#81A1C1"
+theme[free_mid]="#88C0D0"
+theme[free_end]="#ECEFF4"
+
+# Mem/Disk cached meter
+theme[cached_start]="#81A1C1"
+theme[cached_mid]="#88C0D0"
+theme[cached_end]="#ECEFF4"
+
+# Mem/Disk available meter
+theme[available_start]="#81A1C1"
+theme[available_mid]="#88C0D0"
+theme[available_end]="#ECEFF4"
+
+# Mem/Disk used meter
+theme[used_start]="#81A1C1"
+theme[used_mid]="#88C0D0"
+theme[used_end]="#ECEFF4"
+
+# Download graph colors
+theme[download_start]="#81A1C1"
+theme[download_mid]="#88C0D0"
+theme[download_end]="#ECEFF4"
+
+# Upload graph colors
+theme[upload_start]="#81A1C1"
+theme[upload_mid]="#88C0D0"
+theme[upload_end]="#ECEFF4"

--- a/themes/rose-pine/btop.theme
+++ b/themes/rose-pine/btop.theme
@@ -1,0 +1,119 @@
+# Main background, empty for terminal default, need to be empty if you want transparent background
+theme[main_bg]="#191724"
+# Base
+
+# Main text color
+theme[main_fg]="#e0def4"
+# Text
+
+# Title color for boxes
+theme[title]="#908caa"
+# Subtle
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#e0def4"
+# Text
+
+# Background color of selected item in processes box
+theme[selected_bg]="#524f67"
+# HL High
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#f6c177"
+# Gold
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#403d52"
+# HL Med
+
+# Color of text appearing on top of graphs, i.e uptime and current network graph scaling
+theme[graph_text]="#9ccfd8"
+# Foam
+
+# Background color of the percentage meters
+theme[meter_bg]="#9ccfd8"
+# Foam
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#c4a7e7"
+# Iris
+
+# Cpu box outline color
+theme[cpu_box]="#ebbcba"
+# Rose
+
+# Memory/disks box outline color
+theme[mem_box]="#31748f"
+# Pine
+
+# Net up/down box outline color
+theme[net_box]="#c4a7e7"
+# Iris
+
+# Processes box outline color
+theme[proc_box]="#eb6f92"
+# Love
+
+# Box divider line and small boxes line color
+theme[div_line]="#6e6a86"
+# Muted
+
+# Temperature graph colors
+theme[temp_start]="#ebbcba"
+# Rose
+theme[temp_mid]="#f6c177"
+# Gold
+theme[temp_end]="#eb6f92"
+# Love
+
+# CPU graph colors
+theme[cpu_start]="#f6c177"
+# Gold
+theme[cpu_mid]="#ebbcba"
+# Rose
+theme[cpu_end]="#eb6f92"
+# Love
+
+# Mem/Disk free meter
+# all love
+theme[free_start]="#eb6f92"
+theme[free_mid]="#eb6f92"
+theme[free_end]="#eb6f92"
+
+# Mem/Disk cached meter
+# all iris
+theme[cached_start]="#c4a7e7"
+theme[cached_mid]="#c4a7e7"
+theme[cached_end]="#c4a7e7"
+
+# Mem/Disk available meter
+# all pine
+theme[available_start]="#31748f"
+theme[available_mid]="#31748f"
+theme[available_end]="#31748f"
+
+# Mem/Disk used meter
+# all rose
+theme[used_start]="#ebbcba"
+theme[used_mid]="#ebbcba"
+theme[used_end]="#ebbcba"
+
+# Download graph colors
+# Pine for start, foam for the rest
+theme[download_start]="#31748f"
+theme[download_mid]="#9ccfd8"
+theme[download_end]="#9ccfd8"
+
+# Upload graph colors
+theme[upload_start]="#ebbcba"
+# Rose for start
+theme[upload_mid]="#eb6f92"
+# Love for mid and end
+theme[upload_end]="#eb6f92"
+
+# Process box color gradient for threads, mem and cpu usage
+theme[process_start]="#31748f"
+# Pine
+theme[process_mid]="#9ccfd8"
+# Foam for mid and end
+theme[process_end]="#9ccfd8"

--- a/themes/tokyo-night/btop.theme
+++ b/themes/tokyo-night/btop.theme
@@ -1,0 +1,81 @@
+# Theme: tokyo-night
+# By: Pascal Jaeger
+
+# Main bg
+theme[main_bg]="#1a1b26"
+
+# Main text color
+theme[main_fg]="#cfc9c2"
+
+# Title color for boxes
+theme[title]="#cfc9c2"
+
+# Highlight color for keyboard shortcuts
+theme[hi_fg]="#7dcfff"
+
+# Background color of selected item in processes box
+theme[selected_bg]="#414868"
+
+# Foreground color of selected item in processes box
+theme[selected_fg]="#cfc9c2"
+
+# Color of inactive/disabled text
+theme[inactive_fg]="#565f89"
+
+# Misc colors for processes box including mini cpu graphs, details memory graph and details status text
+theme[proc_misc]="#7dcfff"
+
+# Cpu box outline color
+theme[cpu_box]="#565f89"
+
+# Memory/disks box outline color
+theme[mem_box]="#565f89"
+
+# Net up/down box outline color
+theme[net_box]="#565f89"
+
+# Processes box outline color
+theme[proc_box]="#565f89"
+
+# Box divider line and small boxes line color
+theme[div_line]="#565f89"
+
+# Temperature graph colors
+theme[temp_start]="#9ece6a"
+theme[temp_mid]="#e0af68"
+theme[temp_end]="#f7768e"
+
+# CPU graph colors
+theme[cpu_start]="#9ece6a"
+theme[cpu_mid]="#e0af68"
+theme[cpu_end]="#f7768e"
+
+# Mem/Disk free meter
+theme[free_start]="#9ece6a"
+theme[free_mid]="#e0af68"
+theme[free_end]="#f7768e"
+
+# Mem/Disk cached meter
+theme[cached_start]="#9ece6a"
+theme[cached_mid]="#e0af68"
+theme[cached_end]="#f7768e"
+
+# Mem/Disk available meter
+theme[available_start]="#9ece6a"
+theme[available_mid]="#e0af68"
+theme[available_end]="#f7768e"
+
+# Mem/Disk used meter
+theme[used_start]="#9ece6a"
+theme[used_mid]="#e0af68"
+theme[used_end]="#f7768e"
+
+# Download graph colors
+theme[download_start]="#9ece6a"
+theme[download_mid]="#e0af68"
+theme[download_end]="#f7768e"
+
+# Upload graph colors
+theme[upload_start]="#9ece6a"
+theme[upload_mid]="#e0af68"
+theme[upload_end]="#f7768e"


### PR DESCRIPTION
Just to extend the theme consistency to this panel too.

Most of the themes were retrieved from the same [`Btop` repository](https://github.com/aristocratos/btop/tree/main/themes), while the others from the [`catppuccin`](https://github.com/catppuccin/btop) and [`rose-pine`](https://github.com/rose-pine/btop) repositories.

Here an example with `tokyo-night`

![image](https://github.com/user-attachments/assets/092120b9-6342-4e89-97fa-e58af2fe45af)
