### PR TITLE
Fix PHP installation in no-LTS version

### DIFF
--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -21,6 +21,7 @@ if [[ -n "$languages" ]]; then
       ;;
     PHP)
       sudo add-apt-repository -y ppa:ondrej/php
+      sudo sed -i 's/"$(lsb_release -sc)"/noble/g' /etc/apt/sources.list.d/ondrej-ubuntu-php-"$(lsb_release -sc)".sources
       sudo apt -y install php8.4 php8.4-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
       php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
       php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
I did a little research around and indeed the `ppa:ondrej/php` repository **does not support** non-LTS versions of Ubuntu. 

However it's  possible to [force](https://askubuntu.com/questions/1530400/install-older-php-versions-on-24-10) this to use the repository associated with noble in order to make PHP available for other versions as well.

![Schermata da 2025-05-19 23-17-38](https://github.com/user-attachments/assets/5bdbbcb3-d820-4e14-98f1-981c2af64d58)

Fixes this #342 