### PR TITLE
Record the migrations ran

### DIFF
--- a/bin/omakub-sub/migrate.sh
+++ b/bin/omakub-sub/migrate.sh
@@ -64,7 +64,7 @@ for file in $OMAKUB_PATH/migrations/*.sh; do
 
   # Skip this migration if we shouldn't run it
   if ! $should_run; then
-    echo "Migration $migrate_at skipped: $migration_reason"
+    # echo "Migration $migrate_at skipped: $migration_reason"
     continue
   fi
 

--- a/bin/omakub-sub/migrate.sh
+++ b/bin/omakub-sub/migrate.sh
@@ -1,3 +1,5 @@
+cd $OMAKUB_PATH
+
 # Path to the local migrations tracking file
 MIGRATIONS_FILE=~/.config/omakub/migrations.txt
 
@@ -78,3 +80,6 @@ for file in $OMAKUB_PATH/migrations/*.sh; do
     echo "Migration $migrate_at failed. Not recording as executed."
   fi
 done
+
+cd -
+# End of script

--- a/bin/omakub-sub/migrate.sh
+++ b/bin/omakub-sub/migrate.sh
@@ -81,5 +81,8 @@ for file in $OMAKUB_PATH/migrations/*.sh; do
   fi
 done
 
+# Clear the shell messages (clear the terminal)
+clear
+
 cd -
 # End of script

--- a/bin/omakub-sub/migrate.sh
+++ b/bin/omakub-sub/migrate.sh
@@ -1,15 +1,80 @@
-cd $OMAKUB_PATH
-last_updated_at=$(git log -1 --format=%cd --date=unix)
+# Path to the local migrations tracking file
+MIGRATIONS_FILE=~/.config/omakub/migrations.txt
+
+# Check if the migrations file exists
+if [ ! -f "$MIGRATIONS_FILE" ]; then
+  if gum confirm "It appears you don't have a migrations file. Do you want to create it?"; then
+    echo "Running utils/dump-migrations.sh..."
+    # Assuming utils/dump-migrations.sh is in the same directory or in PATH
+    # Adjust the path if necessary, e.g., "$OMAKUB_PATH/utils/dump-migrations.sh"
+    if [ -f "$OMAKUB_PATH/utils/dump-migrations.sh" ]; then
+      sh "$OMAKUB_PATH/utils/dump-migrations.sh"
+    else
+      echo "Error: utils/dump-migrations.sh not found."
+      return 1
+    fi
+  fi
+fi
+
+# Create the migrations tracking file if it doesn't exist
+touch "$MIGRATIONS_FILE"
+
+# Load the list of already executed migrations
+EXECUTED_MIGRATIONS=()
+while IFS= read -r line; do
+  EXECUTED_MIGRATIONS+=("$line")
+done < "$MIGRATIONS_FILE"
+
+# Update the local repository with the latest changes from the remote repository
 git pull
 
+# Iterate through all shell script files in the migrations directory
 for file in $OMAKUB_PATH/migrations/*.sh; do
+  # Extract just the filename without the directory path
   filename=$(basename "$file")
+  
+  # Remove the .sh extension to get the migration timestamp
+  # Migration files are named with Unix timestamps (e.g., 1747474348.sh)
   migrate_at="${filename%.sh}"
 
-  if [ $migrate_at -gt $last_updated_at ]; then
-    echo "Running migration for $migrate_at"
-    source $file
+  # Check if this migration has already been executed by looking for its timestamp
+  # in the EXECUTED_MIGRATIONS array
+  already_executed=false
+  for executed in "${EXECUTED_MIGRATIONS[@]}"; do
+    if [[ "$executed" == "$migrate_at" ]]; then
+      already_executed=true
+      break
+    fi
+  done
+
+  # Check if we should run this migration
+  should_run=false
+  migration_reason=""
+
+  # Only use the recorded migrations file to determine if migration should run
+  if $already_executed; then
+    should_run=false
+    migration_reason="already executed (recorded in migrations file)"
+  else
+    should_run=true
+    migration_reason="not found in migrations record"
+  fi
+
+  # Skip this migration if we shouldn't run it
+  if ! $should_run; then
+    echo "Migration $migrate_at skipped: $migration_reason"
+    continue
+  fi
+
+  # Display which migration is being executed
+  echo "Running migration for $migrate_at"
+  
+  # Run the migration and only record it if it succeeds
+  if source "$file"; then
+    # Record this migration as executed by adding its timestamp to the migrations file
+    echo "$migrate_at" >> "$MIGRATIONS_FILE"
+    echo "Migration $migrate_at executed successfully and recorded."
+  else
+    echo "Migration $migrate_at failed. Not recording as executed."
   fi
 done
-
-cd -

--- a/bin/omakub-sub/migrate.sh
+++ b/bin/omakub-sub/migrate.sh
@@ -28,7 +28,7 @@ while IFS= read -r line; do
 done < "$MIGRATIONS_FILE"
 
 # Update the local repository with the latest changes from the remote repository
-git pull
+git pull > /dev/null
 
 # Iterate through all shell script files in the migrations directory
 for file in $OMAKUB_PATH/migrations/*.sh; do

--- a/utils/add-migration.sh
+++ b/utils/add-migration.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Script to generate a new empty .sh file named with the current Unix timestamp
+# in a specified directory.
+
+# --- Configuration ---
+# Set to true to use a more human-readable date format (YYYYMMDD_HHMMSS.sh)
+# Set to false to use Unix timestamp (e.g., 1718359027.sh)
+USE_HUMAN_READABLE_DATE=false
+
+# --- Script Logic ---
+
+# Check if a directory argument is provided
+# if [ -z "$1" ]; then
+#   echo "Usage: $0 <directory_path>"
+#   echo "Example: $0 /home/joel/migrations"
+#   exit 1
+# fi
+
+# TARGET_DIR="$1"
+TARGET_DIR="${HOME}/.local/share/omakub/migrations"
+
+# Check if the provided path actually exists and is a directory
+if [ ! -d "$TARGET_DIR" ]; then
+  echo "Error: Directory '$TARGET_DIR' does not exist or is not a directory."
+  sleep 2
+  exit 1
+fi
+
+# Check if the directory is writable
+if [ ! -w "$TARGET_DIR" ]; then
+  echo "Error: Directory '$TARGET_DIR' is not writable. Please check permissions."
+  sleep 2
+  exit 1
+fi
+
+# Generate the filename
+if [ "$USE_HUMAN_READABLE_DATE" = true ]; then
+  # Human-readable format: YYYYMMDD_HHMMSS.sh
+  FILENAME="$(date +'%Y%m%d_%H%M%S').sh"
+else
+  # Unix timestamp format (seconds since epoch): 1718359027.sh
+  # This matches the pattern you initially provided.
+  CURRENT_TIMESTAMP=$(date +%s)
+  FILENAME="${CURRENT_TIMESTAMP}.sh"
+fi
+
+FULL_PATH="${TARGET_DIR}/${FILENAME}"
+
+# Check if a file with this name already exists (optional, as touch handles it)
+# Timestamps are generally unique enough, but good for awareness.
+if [ -e "$FULL_PATH" ]; then
+  echo "Warning: File '$FULL_PATH' already exists. Touch will update its timestamp."
+fi
+
+# Create the empty file
+if touch "$FULL_PATH"; then
+  echo "Successfully created empty file: $FULL_PATH"
+  # You can optionally make it executable if these are typically scripts to be run
+  # chmod +x "$FULL_PATH"
+  # echo "Made file executable: $FULL_PATH"
+else
+  echo "Error: Failed to create file '$FULL_PATH'."
+  sleep 2
+  exit 1
+fi
+
+# exit 0

--- a/utils/dump-migrations.sh
+++ b/utils/dump-migrations.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# filepath: /home/joel/.local/share/omakub/bin/omakub-sub/dump-migrations.sh
+# This script initializes ~/.config/omakub/migrations.txt with the migration timestamps
+# from all migration scripts in $OMAKUB_PATH/migrations/*.sh, sorted in ascending order.
+
+set -e
+
+# Ensure ~/.config/omakub exists
+mkdir -p ~/.config/omakub
+
+# Path to the migrations tracking file
+MIGRATIONS_FILE=~/.config/omakub/migrations.txt
+
+# Clear the migrations file if it exists
+> "$MIGRATIONS_FILE"
+
+# Find all migration scripts, extract their timestamps, sort, and write to the file
+for file in "$OMAKUB_PATH"/migrations/*.sh; do
+  filename=$(basename "$file")
+  migrate_at="${filename%.sh}"
+  # Only add if it's a valid number (timestamp)
+  if [[ "$migrate_at" =~ ^[0-9]+$ ]]; then
+    echo "$migrate_at"
+  fi
+done | sort -n > "$MIGRATIONS_FILE"
+
+echo "Migrations dumped to $MIGRATIONS_FILE"


### PR DESCRIPTION
The main issue is that when a migration fails, we cannot determine the final state of the machine's configuration. 

We are unable to identify which specific migration caused the failure. 

The migrations are not idempotent, meaning they cannot be replayed safely. 

Any failure requires manual investigation. 

This lack of clarity undermines trust in the process.

This pull request aims to initiate the traceability of executed migrations, but I believe migrations require further consideration.