### PR TITLE
Default PHP on new Ubuntu versions gte 25.04

### DIFF
--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -21,8 +21,12 @@ if [[ -n "$languages" ]]; then
       mise use --global go@latest
       ;;
     PHP)
-      sudo add-apt-repository -y ppa:ondrej/php
-      sudo apt -y install php8.4 php8.4-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
+      if dpkg --compare-versions "$ubuntu_version" lt "25.04"; then
+        sudo add-apt-repository -y ppa:ondrej/php
+        sudo apt -y install php8.4 php8.4-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
+      else
+        sudo apt -y install php php-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip} --no-install-recommends
+      fi
       php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
       php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
       rm composer-setup.php


### PR DESCRIPTION
- New Ubuntu versions eventually update PHP versions to the latest ones, so there is no need for `ppa:ondrej/php` and also no need to prefix installs with the version (`php8.4-curl...`).
- To prevent issues on versions earlier than 25.04, the old approach is used.
- **Fixes the issue during installation because `ppa:ondrej/php` does not exist for Ubuntu 25.04.**
- On 25.04, `apache2` is installed as a recommendation, we prevent that using the `--no-install-recommends` flag.
