### PR TITLE
Make Alacritty start in Fullscreen mode

### DIFF
--- a/configs/alacritty/shared.toml
+++ b/configs/alacritty/shared.toml
@@ -9,6 +9,7 @@ padding.x = 16
 padding.y = 14
 decorations = "None"
 opacity = 0.98
+startup_mode = "Fullscreen"
 
 [keyboard]
 bindings = [


### PR DESCRIPTION
Given that Omakub is workspace focused, and the demo video talks about a "one app per workspace" flow (6:49-7:24), it would seem to make sense to default Alacritty to fullscreen.