### PR TITLE
Add script for uninstalling vscode

### DIFF
--- a/uninstall/app-vscode.sh
+++ b/uninstall/app-vscode.sh
@@ -1,0 +1,2 @@
+sudo apt purge -y remove code
+rm -rf ~/.config/Code/User


### PR DESCRIPTION
Script for uninstalling vscode was missing. `set-vscode-theme.sh` already checks for presence of vscode before setting themes.