### PR TITLE
Use PHP distro version

### DIFF
--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -21,8 +21,7 @@ if [[ -n "$languages" ]]; then
       mise use --global go@latest
       ;;
     PHP)
-      sudo add-apt-repository -y ppa:ondrej/php
-      sudo apt -y install php8.4 php8.4-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
+      sudo apt -y install php php-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip} --no-install-recommends
       php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
       php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
       rm composer-setup.php

--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -20,8 +20,8 @@ if [[ -n $languages ]]; then
       mise uninstall go@latest
       ;;
     PHP)
-      sudo apt -y purge php8.4 php8.4-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
-      sudo add-apt-repository -y --remove ppa:ondrej/php
+      sudo apt -y purge php php-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
+      sudo apt -y autoremove
       sudo rm /usr/local/bin/composer
       ;;
     Python)


### PR DESCRIPTION
As [discussed](https://github.com/basecamp/omakub/pull/461#issuecomment-3042596706) in this [PR](https://github.com/basecamp/omakub/pull/461), to avoid installation errors and the need to constantly update the PHP version after each new release, we decided to use the version provided by the distribution.

We expect Mise to support PHP versioning in the future, at which point we’ll consider switching to it.

This PR overwrites #475  , closes #342 and closes #413 .