### PR TITLE
change spotify repository url to https

### DIFF
--- a/install/desktop/optional/app-spotify.sh
+++ b/install/desktop/optional/app-spotify.sh
@@ -1,5 +1,5 @@
 # Stream music using https://spotify.com
 curl -sS https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/spotify.gpg] http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
+echo "deb [signed-by=/etc/apt/trusted.gpg.d/spotify.gpg] https://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt update -y
 sudo apt install -y spotify-client


### PR DESCRIPTION
Fixing spotify.list config to remove this warning and make the transport secure 

<img width="871" height="177" alt="image" src="https://github.com/user-attachments/assets/53ee9035-e6dd-4ec1-aba2-29db2d448f96" />
