### PR TITLE
Add arch=amd64 to brave repo config

### DIFF
--- a/install/desktop/optional/app-brave.sh
+++ b/install/desktop/optional/app-brave.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
+echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
 sudo apt update -y
 sudo apt install -y brave-browser


### PR DESCRIPTION
Avoid warning message when doing an "apt update"