### PR TITLE
Fix .bashrc and .inputrc backups

### DIFF
--- a/install/terminal/a-shell.sh
+++ b/install/terminal/a-shell.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Configure the bash shell using Omakub defaults
-[ -f "~/.bashrc" ] && mv ~/.bashrc ~/.bashrc.bak
+[ -f ~/.bashrc ] && mv ~/.bashrc ~/.bashrc.bak
 cp ~/.local/share/omakub/configs/bashrc ~/.bashrc
 
 # Load the PATH for use later in the installers
 source ~/.local/share/omakub/defaults/bash/shell
 
-[ -f "~/.inputrc" ] && mv ~/.inputrc ~/.inputrc.bak
+[ -f ~/.inputrc ] && mv ~/.inputrc ~/.inputrc.bak
 # Configure the inputrc using Omakub defaults
 cp ~/.local/share/omakub/configs/inputrc ~/.inputrc


### PR DESCRIPTION
In my tests, I noticed that `.bashrc.bak` was not being created, so I took a look and found out this issue.

- `[ -f "~/.foo" ]` is basically always false since tilde expansion (~) does not work inside quotes