### PR TITLE
Enable editor.quickSuggestions for vscode intellisense

### DIFF
--- a/configs/vscode.json
+++ b/configs/vscode.json
@@ -10,7 +10,7 @@
   "editor.suggestOnTriggerCharacters": false,
   "editor.tabCompletion": "on",
   "editor.quickSuggestions": {
-    "other": false,
+    "other": true,
     "comments": false,
     "strings": false
   },


### PR DESCRIPTION
Intellisense was not showing suggestions in vscode. Set editor.quickSuggestions to recommended [default values ](https://code.visualstudio.com/docs/editing/intellisense#_customizing-intellisense)