### PR TITLE
Disable application hotkeys to free up Super+Number

### DIFF
--- a/install/desktop/set-gnome-hotkeys.sh
+++ b/install/desktop/set-gnome-hotkeys.sh
@@ -19,6 +19,9 @@ gsettings set org.gnome.desktop.wm.keybindings toggle-fullscreen "['<Shift>F11']
 gsettings set org.gnome.mutter dynamic-workspaces false
 gsettings set org.gnome.desktop.wm.preferences num-workspaces 6
 
+# Disable the hotkeys in the Dash to Dock extension (most likely culprit)
+gsettings set org.gnome.shell.extensions.dash-to-dock hot-keys false
+
 # Use alt for pinned apps
 gsettings set org.gnome.shell.keybindings switch-to-application-1 "['<Alt>1']"
 gsettings set org.gnome.shell.keybindings switch-to-application-2 "['<Alt>2']"


### PR DESCRIPTION
resolve workspaces keybinding conflict with application shortcuts that still use ubuntu dock