### PR TITLE
Add explicit dependency on bash-completion

### DIFF
--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,7 +3,7 @@
 # Needed for all installers
 sudo apt update -y
 sudo apt upgrade -y
-sudo apt install -y curl git unzip
+sudo apt install -y curl git unzip bash-completion
 
 # Run terminal installers
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done


### PR DESCRIPTION
First time trying Omakube and I got an error about no such file when the scripts tried to source the bash_completion file.

I've installed Ubuntu in a slightly non-standard way using [zfsbootmenu](https://docs.zfsbootmenu.org/en/v3.0.x/guides/ubuntu/uefi.html) which is why it was not installed by default.