### PR TITLE
feat: custom clone url by OMAKUB_URL environment

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -19,7 +19,7 @@ sudo apt-get install -y git >/dev/null
 
 echo "Cloning Omakub..."
 rm -rf ~/.local/share/omakub
-git clone https://github.com/basecamp/omakub.git ~/.local/share/omakub >/dev/null
+git clone "${OMAKUB_URL:-https://github.com/basecamp/omakub.git}" ~/.local/share/omakub >/dev/null
 if [[ $OMAKUB_REF != "master" ]]; then
 	cd ~/.local/share/omakub
 	git fetch origin "${OMAKUB_REF:-stable}" && git checkout "${OMAKUB_REF:-stable}"


### PR DESCRIPTION
This pull-request makes us changeable clone url. a little more feel casual to use customized Omakub.

### Test

#### no OMAKUB_URL case:

I ran following and saw cloning official repository:

```console
$ wget -qO- https://raw.githubusercontent.com/nishidayuya/omakub/refs/heads/feat_custom_clone_url/boot.sh |
    bash -x
```

#### set OMAKUB_URL case:

I ran following and saw cloning my forked repository:

```console
$ wget -qO- https://raw.githubusercontent.com/nishidayuya/omakub/refs/heads/feat_custom_clone_url/boot.sh |
    OMAKUB_URL=https://github.com/nishidayuya/omakub.git \
    OMAKUB_REF=feat_batch_installation \
    bash -x
```
