### PR TITLE
List hidden and ignored files in file Explorer Snack Picker plugin

### DIFF
--- a/configs/neovim/snacks-picker.lua
+++ b/configs/neovim/snacks-picker.lua
@@ -1,0 +1,18 @@
+return {
+	"folke/snacks.nvim",
+	opts = {
+		picker = {
+			sources = {
+				files = {
+					hidden = true,
+				},
+				explorer = {
+					hidden = true,
+				},
+				grep = {
+					hidden = true,
+				},
+			},
+		},
+	},
+}


### PR DESCRIPTION
Permit list hidden and ignored files by grep command, file explorer and telescope.
## Side Bar File Explorer
<img width="713" height="466" alt="image" src="https://github.com/user-attachments/assets/cdcaa728-ee48-48f7-bbbc-5ce8e3bfe1bd" />
## Telescope
<img width="1524" height="380" alt="image" src="https://github.com/user-attachments/assets/894a4ac2-8cd5-40ff-a1f4-b3ab1f92d752" />
## When Grep
<img width="1524" height="380" alt="image" src="https://github.com/user-attachments/assets/4e839b8a-487e-4523-9ffe-88bd568be138" />


