### PR TITLE
chore: fix theme for tophat

### DIFF
--- a/themes/matte-black/tophat.sh
+++ b/themes/matte-black/tophat.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#1e1e1e"
+gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#FFFFFF"


### PR DESCRIPTION
- fix indicator colors for tophat in matte black because they are black and kinda duplicate with background color