### PR TITLE
Update signal installation

### DIFF
--- a/install/desktop/app-signal.sh
+++ b/install/desktop/app-signal.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-wget -qO- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor >signal-desktop-keyring.gpg
-cat signal-desktop-keyring.gpg | sudo tee /usr/share/keyrings/signal-desktop-keyring.gpg >/dev/null
-echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/signal-desktop-keyring.gpg] https://updates.signal.org/desktop/apt xenial main' |
-	sudo tee /etc/apt/sources.list.d/signal-xenial.list
+wget -O- https://updates.signal.org/desktop/apt/keys.asc | gpg --dearmor > signal-desktop-keyring.gpg;
+cat signal-desktop-keyring.gpg | sudo tee /usr/share/keyrings/signal-desktop-keyring.gpg > /dev/null
+wget -O signal-desktop.sources https://updates.signal.org/static/desktop/apt/signal-desktop.sources;
+cat signal-desktop.sources | sudo tee /etc/apt/sources.list.d/signal-desktop.sources > /dev/null
 rm signal-desktop-keyring.gpg
+
 sudo apt update
 sudo apt install -y signal-desktop


### PR DESCRIPTION
Updated installation method using the [official Signal instructions](https://signal.org/download/linux/).
