### PR TITLE
Update uninstall script to remove Neovim files

### DIFF
--- a/uninstall/app-neovim.sh
+++ b/uninstall/app-neovim.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-sudo apt purge -y neovim neovim-runtime
+sudo rm /usr/local/bin/nvim
+sudo rm -r /usr/local/share/nvim/
 rm ~/.local/share/applications/Neovim.desktop
 rm -rf ~/.config/nvim
 rm -rf ~/.local/share/nvim


### PR DESCRIPTION
Neovim is not installed via apt, but via manual installation from binaries. Therefore, the generated package must be removed.