### PR TITLE
Update capslock behavior from emoji compose to keyboard layout toggle

### DIFF
--- a/install/desktop/set-xcompose.sh
+++ b/install/desktop/set-xcompose.sh
@@ -2,4 +2,4 @@
 
 envsubst < ~/.local/share/omakub/configs/xcompose > ~/.XCompose
 ibus restart
-gsettings set org.gnome.desktop.input-sources xkb-options "['compose:caps']"
+gsettings set org.gnome.desktop.input-sources xkb-options "['grp:caps_toggle']"


### PR DESCRIPTION
## Summary
- Changed xkb-options from `compose:caps` to `grp:caps_toggle` in `install/desktop/set-xcompose.sh`
- Capslock now toggles between keyboard layouts instead of acting as a compose key for emoji shortcuts
- Provides more flexibility for users who need to switch between different keyboard layouts

## Test plan
- [ ] Run `bash install/desktop/set-xcompose.sh` to apply the new configuration
- [ ] Verify that capslock toggles between configured keyboard layouts
- [ ] Ensure no errors occur during the setup process

🤖 Generated with [Claude Code](https://claude.com/claude-code)