### PR TITLE
Improve theme installation experience

### DIFF
--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-THEME_NAMES=("Tokyo Night" "Catppuccin" "Nord" "Everforest" "Gruvbox" "Kanagawa" "Ristretto" "Rose Pine" "Matte Black" "Osaka Jade")
-THEME=$(gum choose "${THEME_NAMES[@]}" "<< Back" --header "Choose your theme" --height 12 | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
+THEME_LIST=()
+while IFS= read -r path; do
+  THEME_LIST+=("$(basename "$path" | sed -E 's/(^|-)([a-z])/\1\u\2/g; s/-/ /g')")
+done < <(find "$OMAKUB_PATH/themes/" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) | sort)
+
+THEME=$(gum choose "${THEME_LIST[@]}" "<< Back" --header "Choose your theme" --height "$((${#THEME_LIST[@]} + 2))" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')
 
 if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
   cp $OMAKUB_PATH/themes/$THEME/alacritty.toml ~/.config/alacritty/theme.toml


### PR DESCRIPTION
Taking inspiration from this #527 , I think this selection could also be improved so that adding the theme here each time wouldn’t be necessary.

<img width="862" height="660" alt="Screenshot From 2025-11-10 00-06-16" src="https://github.com/user-attachments/assets/43057ee6-091d-4717-87d8-271f8a9252b8" />
