### PR TITLE
Fix typo in Brave installer

### DIFF
--- a/install/desktop/optional/app-brave.sh
+++ b/install/desktop/optional/app-brave.sh
@@ -4,7 +4,7 @@ if [ ! -f /etc/apt/sources.list.d/brave-browser-release.list ]; then
   [ -f /usr/share/keyrings/brave-browser-archive-keyring.gpg ] && sudo rm /usr/share/keyrings/brave-browser-archive-keyring.gpg
   sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
   echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
-if
+fi
 
 sudo apt update
 sudo apt install -y brave-browser


### PR DESCRIPTION
This is simply a replica of the fix proposed in this #568 , which is actually necessary for Brave to work. Since that PR has been closed, I'm reposting it.