### PR TITLE
chore: configure Docker daemon min API version

### DIFF
--- a/install/terminal/docker.sh
+++ b/install/terminal/docker.sh
@@ -17,4 +17,6 @@ sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin d
 sudo usermod -aG docker ${USER}
 
 # Limit log size to avoid running out of disk
-echo '{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json
+echo '{"min-api-version": "1.24","log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"5"}}' | sudo tee /etc/docker/daemon.json
+sudo systemctl daemon-reload
+sudo systemctl restart docker


### PR DESCRIPTION
This is a solution to an error that occurs with the same lazydocker. Of course, everything will be fixed later, but here and now is the solution to this problem.