### PR TITLE
Drop i686 architecture check

### DIFF
--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -17,12 +17,12 @@ if [ "$ID" != "ubuntu" ] || [ $(echo "$VERSION_ID >= 24.04" | bc) != 1 ]; then
   exit 1
 fi
 
-# Check if running on x86
+# Check if running on x86_64
 ARCH=$(uname -m)
-if [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "i686" ]; then
+if [ "$ARCH" != "x86_64" ]; then
   echo "$(tput setaf 1)Error: Unsupported architecture detected"
   echo "Current architecture: $ARCH"
-  echo "This installation is only supported on x86 architectures (x86_64 or i686)."
+  echo "This installation is only supported on x86 architectures."
   echo "Installation stopped."
   exit 1
 fi

--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -22,7 +22,7 @@ ARCH=$(uname -m)
 if [ "$ARCH" != "x86_64" ]; then
   echo "$(tput setaf 1)Error: Unsupported architecture detected"
   echo "Current architecture: $ARCH"
-  echo "This installation is only supported on x86 architectures."
+  echo "This installation is only supported on x86_64 architectures."
   echo "Installation stopped."
   exit 1
 fi


### PR DESCRIPTION
During the installation process, only applications for the 64-bit architecture are downloaded and installed. Omakub simply won't install properly on 32-bit processors. You either need to abandon the 32-bit architecture or specify dependencies where necessary.