### PR TITLE
refactor(apt): align repository configuration with Ubuntu .sources standard

### DIFF
--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -3,7 +3,7 @@
 # Needed for all installers
 sudo apt update -y
 sudo apt upgrade -y
-sudo apt install -y curl git unzip
+sudo apt install -y curl git unzip gnupg
 
 # Run terminal installers
 for installer in ~/.local/share/omakub/install/terminal/*.sh; do source $installer; done

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -5,9 +5,7 @@
 # Load OS release information
 . /etc/os-release
 if [ ! -f /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources ]; then
-    sudo mkdir -p /etc/apt/keyrings
-    sudo rm -f /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc
-
+    [ -f /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc ] && sudo rm /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc
     curl -fsSL \
         "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xeb65ee19d802f3eb1a13cfe47e2e5cb4d4865f21" \
         | sudo tee /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc > /dev/null

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
 
 # Display system information in the terminal
-sudo add-apt-repository -y ppa:zhangsongcui3371/fastfetch
+#
+# Load OS release information
+. /etc/os-release
+if [ ! -f /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources ]; then
+    sudo mkdir -p /etc/apt/keyrings
+    sudo rm -f /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc
+
+    curl -fsSL \
+        "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xeb65ee19d802f3eb1a13cfe47e2e5cb4d4865f21" \
+        | sudo tee /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc > /dev/null
+
+    printf '%s\n' \
+        "Types: deb deb-src" \
+        "URIs: https://ppa.launchpadcontent.net/zhangsongcui3371/fastfetch/ubuntu" \
+        "Suites: ${VERSION_CODENAME}" \
+        "Components: main" \
+        "Architectures: amd64" \
+        "Signed-By: /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc" \
+        | sudo tee /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources > /dev/null
+fi
+
 sudo apt update -y
 sudo apt install -y fastfetch
 

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -2,7 +2,6 @@
 
 # Display system information in the terminal
 if [ ! -f /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources ]; then
-	sudo apt install -y gnupg
 	[ -f /etc/apt/keyrings/zhangsongcui3371-fastfetch.gpg ] && sudo rm /etc/apt/keyrings/zhangsongcui3371-fastfetch.gpg
 	gpg --keyserver keyserver.ubuntu.com --recv 0x7e2e5cb4d4865f21
 	gpg --export 0x7e2e5cb4d4865f21 | sudo tee /usr/share/keyrings/zhangsongcui3371-fastfetch.gpg >/dev/null

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -1,23 +1,19 @@
 #!/bin/bash
 
 # Display system information in the terminal
-#
-# Load OS release information
-. /etc/os-release
 if [ ! -f /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources ]; then
-    [ -f /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc ] && sudo rm /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc
-    curl -fsSL \
-        "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xeb65ee19d802f3eb1a13cfe47e2e5cb4d4865f21" \
-        | sudo tee /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc > /dev/null
-
-    printf '%s\n' \
-        "Types: deb deb-src" \
-        "URIs: https://ppa.launchpadcontent.net/zhangsongcui3371/fastfetch/ubuntu" \
-        "Suites: ${VERSION_CODENAME}" \
-        "Components: main" \
-        "Architectures: amd64" \
-        "Signed-By: /etc/apt/keyrings/zhangsongcui3371-fastfetch.asc" \
-        | sudo tee /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources > /dev/null
+	sudo apt install -y gnupg
+	[ -f /etc/apt/keyrings/zhangsongcui3371-fastfetch.gpg ] && sudo rm /etc/apt/keyrings/zhangsongcui3371-fastfetch.gpg
+	gpg --keyserver keyserver.ubuntu.com --recv 0x7e2e5cb4d4865f21
+	gpg --export 0x7e2e5cb4d4865f21 | sudo tee /usr/share/keyrings/zhangsongcui3371-fastfetch.gpg >/dev/null
+	printf '%s\n' \
+		"Types: deb deb-src" \
+		"URIs: https://ppa.launchpadcontent.net/zhangsongcui3371/fastfetch/ubuntu" \
+		"Suites: ${VERSION_CODENAME}" \
+		"Components: main" \
+		"Architectures: amd64" \
+		"Signed-By: /etc/apt/keyrings/zhangsongcui3371-fastfetch.gpg" |
+		sudo tee /etc/apt/sources.list.d/zhangsongcui3371-fastfetch.sources >/dev/null
 fi
 
 sudo apt update -y
@@ -25,7 +21,7 @@ sudo apt install -y fastfetch
 
 # Only attempt to set configuration if fastfetch is not already set
 if [ ! -f "$HOME/.config/fastfetch/config.jsonc" ]; then
-  # Use Omakub fastfetch config
-  mkdir -p ~/.config/fastfetch
-  cp ~/.local/share/omakub/configs/fastfetch.jsonc ~/.config/fastfetch/config.jsonc
+	# Use Omakub fastfetch config
+	mkdir -p ~/.config/fastfetch
+	cp ~/.local/share/omakub/configs/fastfetch.jsonc ~/.config/fastfetch/config.jsonc
 fi


### PR DESCRIPTION
Migrate PPA and third-party repos to structured .sources format
with explicit Signed-By, Architectures, and proper key handling
in /etc/apt/keyrings/.

P.S. add-apt-repository deprecated. In short, add-apt-repository didn't add keys as separate files, but imported them into the shared keyring. A complete switch to *.sources, with explicit key file specifications, is safer and preferable.