### PR TITLE
fix: correct installation of Yaru accent themes and font configuration

### DIFF
--- a/bin/omakub-sub/font-size.sh
+++ b/bin/omakub-sub/font-size.sh
@@ -4,6 +4,13 @@ choice=$(gum choose {7..14} "<< Back" --height 11 --header "Choose your terminal
 
 if [[ $choice =~ ^[0-9]+$ ]]; then
 	sed -i "s/^size = .*$/size = $choice/g" ~/.config/alacritty/font-size.toml
+
+	OMAKUB_CURRENT_FONT=$(gsettings get org.gnome.desktop.interface font-name | tr -d "'")
+	OMAKUB_FONT_NAME="${OMAKUB_CURRENT_FONT% [0-9]*}"
+	gsettings set org.gnome.desktop.interface font-name "'$OMAKUB_FONT_NAME $choice'"
+	gsettings set org.gnome.desktop.interface monospace-font-name "'$OMAKUB_FONT_NAME Mono $choice'"
+	source "$OMAKUB_PATH/themes/set-qt6-theme.sh"
+
 	source $OMAKUB_PATH/bin/omakub-sub/font-size.sh
 else
 	source $OMAKUB_PATH/bin/omakub-sub/font.sh

--- a/bin/omakub-sub/font.sh
+++ b/bin/omakub-sub/font.sh
@@ -18,7 +18,11 @@ set_font() {
 		source $OMAKUB_PATH/ascii.sh
 	fi
 
-	gsettings set org.gnome.desktop.interface monospace-font-name "$font_name 10"
+	OMAKUB_CURRENT_FONT_SIZE=$(gsettings get org.gnome.desktop.interface font-name | tr -d "'" | awk '{print $NF}')
+	gsettings set org.gnome.desktop.interface font-name "$font_name $OMAKUB_CURRENT_FONT_SIZE"
+	gsettings set org.gnome.desktop.interface monospace-font-name "$font_name Mono $OMAKUB_CURRENT_FONT_SIZE"
+	source "$OMAKUB_PATH/themes/set-qt6-theme.sh"
+
 	cp "$OMAKUB_PATH/configs/alacritty/fonts/$file_name.toml" ~/.config/alacritty/font.toml
 	sed -i "s/\"editor.fontFamily\": \".*\"/\"editor.fontFamily\": \"$font_name\"/g" ~/.config/Code/User/settings.json
 }

--- a/bin/omakub-sub/theme.sh
+++ b/bin/omakub-sub/theme.sh
@@ -19,7 +19,6 @@ if [ -n "$THEME" ] && [ "$THEME" != "<<-back" ]; then
   fi
 
   source $OMAKUB_PATH/themes/$THEME/gnome.sh
-  source $OMAKUB_PATH/themes/$THEME/tophat.sh
   source $OMAKUB_PATH/themes/$THEME/vscode.sh
 
   # Forgo setting the Chrome theme until we might find a less disruptive way of doing it.

--- a/defaults/bash/shell
+++ b/defaults/bash/shell
@@ -4,6 +4,8 @@ HISTCONTROL=ignoreboth
 HISTSIZE=32768
 HISTFILESIZE="${HISTSIZE}"
 
+export QT_QPA_PLATFORMTHEME="qt6ct"
+
 # Autocompletion
 source /usr/share/bash-completion/bash_completion
 

--- a/install/desktop/set-gnome-theme.sh
+++ b/install/desktop/set-gnome-theme.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
 
+# Adding support for QT themes in the style of the main theme
+sudo apt-get install -y qt6ct adwaita-qt
+
+cd /tmp
+rm -f gtk.deb icons.deb
+
+wget -O gtk.deb http://ftp.debian.org/debian/pool/main/y/yaru-theme/yaru-theme-gtk_24.04.3-1_all.deb
+dpkg-deb -x gtk.deb ./yaru-theme/
+
+wget -O icons.deb http://ftp.debian.org/debian/pool/main/y/yaru-theme/yaru-theme-icon_24.04.3-1_all.deb
+dpkg-deb -x icons.deb ./yaru-icons/
+
+mkdir -p ~/.local/share/{themes,icons}
+
+for theme in bark viridian; do
+	cp -R ./yaru-theme/usr/share/themes/Yaru-$theme{,-dark} ~/.local/share/themes/ 2>/dev/null || true
+	cp -R ./yaru-icons/usr/share/icons/Yaru-$theme{,-dark} ~/.local/share/icons/ 2>/dev/null || true
+done
+
+rm -f gtk.deb icons.deb
+rm -rf yaru-theme yaru-icons
+cd -
+
 source ~/.local/share/omakub/themes/tokyo-night/gnome.sh
-source ~/.local/share/omakub/themes/tokyo-night/tophat.sh

--- a/themes/catppuccin/gnome.sh
+++ b/themes/catppuccin/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE="magenta"
 OMAKUB_THEME_ACCENT=("magenta" "pink")
 OMAKUB_THEME_BACKGROUND="catppuccin/background.png"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/catppuccin/gnome.sh
+++ b/themes/catppuccin/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="magenta"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE="magenta"
+OMAKUB_THEME_ACCENT=("magenta" "pink")
 OMAKUB_THEME_BACKGROUND="catppuccin/background.png"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/catppuccin/tophat.sh
+++ b/themes/catppuccin/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#e920a3"

--- a/themes/everforest/gnome.sh
+++ b/themes/everforest/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="bark"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE="bark"
+OMAKUB_THEME_ACCENT=("bark" "slate")
 OMAKUB_THEME_BACKGROUND="everforest/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/everforest/gnome.sh
+++ b/themes/everforest/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE="bark"
 OMAKUB_THEME_ACCENT=("bark" "slate")
 OMAKUB_THEME_BACKGROUND="everforest/background.jpg"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/everforest/tophat.sh
+++ b/themes/everforest/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"

--- a/themes/gruvbox/gnome.sh
+++ b/themes/gruvbox/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE="sage"
 OMAKUB_THEME_ACCENT=("sage" "yellow")
 OMAKUB_THEME_BACKGROUND="gruvbox/background.jpg"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/gruvbox/gnome.sh
+++ b/themes/gruvbox/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="sage"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE="sage"
+OMAKUB_THEME_ACCENT=("sage" "yellow")
 OMAKUB_THEME_BACKGROUND="gruvbox/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/gruvbox/tophat.sh
+++ b/themes/gruvbox/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"

--- a/themes/kanagawa/gnome.sh
+++ b/themes/kanagawa/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE=""
 OMAKUB_THEME_ACCENT=("bark" "yellow")
 OMAKUB_THEME_BACKGROUND="kanagawa/background.jpg"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/kanagawa/gnome.sh
+++ b/themes/kanagawa/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="purple"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE=""
+OMAKUB_THEME_ACCENT=("bark" "yellow")
 OMAKUB_THEME_BACKGROUND="kanagawa/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/kanagawa/tophat.sh
+++ b/themes/kanagawa/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"

--- a/themes/matte-black/gnome.sh
+++ b/themes/matte-black/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE=""
 OMAKUB_THEME_ACCENT=("orange" "yellow")
 OMAKUB_THEME_BACKGROUND="matte-black/background.jpg"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/matte-black/gnome.sh
+++ b/themes/matte-black/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="orange"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE=""
+OMAKUB_THEME_ACCENT=("orange" "yellow")
 OMAKUB_THEME_BACKGROUND="matte-black/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/matte-black/tophat.sh
+++ b/themes/matte-black/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#FFFFFF"

--- a/themes/nord/gnome.sh
+++ b/themes/nord/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="blue"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE="blue"
+OMAKUB_THEME_ACCENT=("slate" "blue")
 OMAKUB_THEME_BACKGROUND="nord/background.png"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/nord/gnome.sh
+++ b/themes/nord/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE="blue"
 OMAKUB_THEME_ACCENT=("slate" "blue")
 OMAKUB_THEME_BACKGROUND="nord/background.png"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/nord/tophat.sh
+++ b/themes/nord/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#208fe9"

--- a/themes/osaka-jade/gnome.sh
+++ b/themes/osaka-jade/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="green"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE="viridian"
+OMAKUB_THEME_ACCENT=("viridian" "green")
 OMAKUB_THEME_BACKGROUND="osaka-jade/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/osaka-jade/tophat.sh
+++ b/themes/osaka-jade/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#214237"

--- a/themes/ristretto/gnome.sh
+++ b/themes/ristretto/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="grey"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE=""
+OMAKUB_THEME_ACCENT=("orange" "yellow")
 OMAKUB_THEME_BACKGROUND="ristretto/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/ristretto/tophat.sh
+++ b/themes/ristretto/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#2c2525"

--- a/themes/rose-pine/gnome.sh
+++ b/themes/rose-pine/gnome.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="red"
+OMAKUB_THEME_PEFER="light"
+OMAKUB_THEME_STYLE="red"
+OMAKUB_THEME_ACCENT=("red")
 OMAKUB_THEME_BACKGROUND="rose-pine/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
-gsettings set org.gnome.desktop.interface color-scheme 'prefer-light'
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/rose-pine/tophat.sh
+++ b/themes/rose-pine/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#e92020"

--- a/themes/set-gnome-theme.sh
+++ b/themes/set-gnome-theme.sh
@@ -48,43 +48,6 @@ gsettings set org.gnome.desktop.interface icon-theme "Yaru${OMAKUB_THEME_STYLE}$
 GNOME_CURRENT_ACCENTS=$(omaku_get_accent "${OMAKUB_THEME_ACCENT[@]}")
 gsettings set org.gnome.desktop.interface accent-color "$GNOME_CURRENT_ACCENTS" 2>/dev/null || true
 
-mkdir -p ~/.config/qt6ct
-
-if [[ "$OMAKUB_THEME_PEFER" == "dark" ]]; then
-    OMAKUB_THEME_SUFFIX="-Dark"
-fi
-
-OMAKUB_THEME_FONTANDSIZE='"'$(gsettings get org.gnome.desktop.interface font-name | tr -d "'" | awk '{
-    size = $NF;
-    name = "";
-    for (i = 1; i < NF; i++) {
-        if (i > 1) name = name " ";
-        name = name $i;
-    }
-    print name "," size;
-}')'"'
-OMAKUB_THEME_FONTANDSIZE_MONO='"'$(gsettings get org.gnome.desktop.interface monospace-font-name | tr -d "'" | awk '{
-    size = $NF;
-    name = "";
-    for (i = 1; i < NF; i++) {
-        if (i > 1) name = name " ";
-        name = name $i;
-    }
-    print name "," size;
-}')'"'
-
-printf "%s\n" \
-    "[Appearance]" \
-    "custom_palette=false" \
-    "icon_theme=Yaru${OMAKUB_THEME_STYLE}${OMAKUB_THEME_SUFFIX}" \
-    "standard_dialogs=gtk3" \
-    "style=Adwaita${OMAKUB_THEME_SUFFIX}" \
-    "" \
-    "[Fonts]" \
-    "general=$OMAKUB_THEME_FONTANDSIZE" \
-    "fixed=$OMAKUB_THEME_FONTANDSIZE_MONO" \
-    "" |
-    tee ~/.config/qt6ct/qt6ct.conf >/dev/null
 
 BACKGROUND_ORG_PATH="$HOME/.local/share/omakub/themes/$OMAKUB_THEME_BACKGROUND"
 BACKGROUND_DEST_DIR="$HOME/.local/share/backgrounds"

--- a/themes/set-gnome-theme.sh
+++ b/themes/set-gnome-theme.sh
@@ -1,18 +1,100 @@
 #!/bin/bash
 
-gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
-gsettings set org.gnome.desktop.interface cursor-theme 'Yaru'
-gsettings set org.gnome.desktop.interface gtk-theme "Yaru-$OMAKUB_THEME_COLOR-dark"
-gsettings set org.gnome.desktop.interface icon-theme "Yaru-$OMAKUB_THEME_COLOR"
-gsettings set org.gnome.desktop.interface accent-color "$OMAKUB_THEME_COLOR" 2>/dev/null || true
+omaku_get_accent() {
+    local -a PREFERRED_COLORS=("$@")
+    get_system_accent_colors() {
+        local range_output
+        range_output=$(gsettings range org.gnome.desktop.interface accent-color 2>/dev/null)
+
+        if [[ -z "$range_output" || "$range_output" == *"type is not an enumeration"* ]]; then
+            echo ""
+            return
+        fi
+        echo "$range_output" | tr -d "[]'" | tr ',' '\n' | awk 'NF'
+    }
+
+    local -a SYSTEM_COLORS
+    readarray -t SYSTEM_COLORS < <(get_system_accent_colors)
+
+    declare -A SYSTEM_SET
+    for c in "${SYSTEM_COLORS[@]}"; do
+        SYSTEM_SET["$c"]=1
+    done
+
+    local SELECTED="default"
+    for color in "${PREFERRED_COLORS[@]}"; do
+        if [[ -n "${SYSTEM_SET[$color]}" ]]; then
+            SELECTED="$color"
+            break
+        fi
+    done
+
+    echo "$SELECTED"
+}
+
+OMAKUB_THEME_SUFFIX=""
+if [[ "$OMAKUB_THEME_PEFER" == "dark" ]]; then
+    OMAKUB_THEME_SUFFIX="-dark"
+fi
+if [ "$OMAKUB_THEME_STYLE" ]; then
+    OMAKUB_THEME_STYLE="-${OMAKUB_THEME_STYLE}"
+fi
+
+gsettings set org.gnome.desktop.interface color-scheme "prefer-${OMAKUB_THEME_PEFER}"
+gsettings set org.gnome.desktop.interface cursor-theme "Yaru"
+gsettings set org.gnome.desktop.interface gtk-theme "Yaru${OMAKUB_THEME_STYLE}${OMAKUB_THEME_SUFFIX}"
+gsettings set org.gnome.desktop.interface icon-theme "Yaru${OMAKUB_THEME_STYLE}${OMAKUB_THEME_SUFFIX}"
+
+GNOME_CURRENT_ACCENTS=$(omaku_get_accent "${OMAKUB_THEME_ACCENT[@]}")
+gsettings set org.gnome.desktop.interface accent-color "$GNOME_CURRENT_ACCENTS" 2>/dev/null || true
+
+mkdir -p ~/.config/qt6ct
+
+if [[ "$OMAKUB_THEME_PEFER" == "dark" ]]; then
+    OMAKUB_THEME_SUFFIX="-Dark"
+fi
+
+OMAKUB_THEME_FONTANDSIZE='"'$(gsettings get org.gnome.desktop.interface font-name | tr -d "'" | awk '{
+    size = $NF;
+    name = "";
+    for (i = 1; i < NF; i++) {
+        if (i > 1) name = name " ";
+        name = name $i;
+    }
+    print name "," size;
+}')'"'
+OMAKUB_THEME_FONTANDSIZE_MONO='"'$(gsettings get org.gnome.desktop.interface monospace-font-name | tr -d "'" | awk '{
+    size = $NF;
+    name = "";
+    for (i = 1; i < NF; i++) {
+        if (i > 1) name = name " ";
+        name = name $i;
+    }
+    print name "," size;
+}')'"'
+
+printf "%s\n" \
+    "[Appearance]" \
+    "custom_palette=false" \
+    "icon_theme=Yaru${OMAKUB_THEME_STYLE}${OMAKUB_THEME_SUFFIX}" \
+    "standard_dialogs=gtk3" \
+    "style=Adwaita${OMAKUB_THEME_SUFFIX}" \
+    "" \
+    "[Fonts]" \
+    "general=$OMAKUB_THEME_FONTANDSIZE" \
+    "fixed=$OMAKUB_THEME_FONTANDSIZE_MONO" \
+    "" |
+    tee ~/.config/qt6ct/qt6ct.conf >/dev/null
 
 BACKGROUND_ORG_PATH="$HOME/.local/share/omakub/themes/$OMAKUB_THEME_BACKGROUND"
 BACKGROUND_DEST_DIR="$HOME/.local/share/backgrounds"
-BACKGROUND_DEST_PATH="$BACKGROUND_DEST_DIR/$(echo $OMAKUB_THEME_BACKGROUND | tr '/' '-')"
+BACKGROUND_DEST_PATH="$BACKGROUND_DEST_DIR/$(echo "$OMAKUB_THEME_BACKGROUND" | tr '/' '-')"
 
 if [ ! -d "$BACKGROUND_DEST_DIR" ]; then mkdir -p "$BACKGROUND_DEST_DIR"; fi
 
-[ ! -f $BACKGROUND_DEST_PATH ] && cp $BACKGROUND_ORG_PATH $BACKGROUND_DEST_PATH
-gsettings set org.gnome.desktop.background picture-uri $BACKGROUND_DEST_PATH
-gsettings set org.gnome.desktop.background picture-uri-dark $BACKGROUND_DEST_PATH
+[ ! -f "$BACKGROUND_DEST_PATH" ] && install "$BACKGROUND_ORG_PATH" "$BACKGROUND_DEST_PATH"
+gsettings set org.gnome.desktop.background picture-uri "$BACKGROUND_DEST_PATH"
+gsettings set org.gnome.desktop.background picture-uri-dark "$BACKGROUND_DEST_PATH"
 gsettings set org.gnome.desktop.background picture-options 'zoom'
+
+source "$OMAKUB_PATH/themes/set-qt6-theme.sh"

--- a/themes/set-qt6-theme.sh
+++ b/themes/set-qt6-theme.sh
@@ -28,7 +28,7 @@ OMAKUB_THEME_FONTANDSIZE_MONO='"'$(gsettings get org.gnome.desktop.interface mon
 printf "%s\n" \
     "[Appearance]" \
     "custom_palette=false" \
-    "icon_theme=Yaru$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")" \
+    "icon_theme=$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")" \
     "standard_dialogs=gtk3" \
     "style=Adwaita${OMAKUB_THEME_SUFFIX}" \
     "" \

--- a/themes/set-qt6-theme.sh
+++ b/themes/set-qt6-theme.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+mkdir -p ~/.config/qt5ct ~/.config/qt6ct
+OMAKUB_THEME_PEFER=$(gsettings get org.gnome.desktop.interface color-scheme | tr -d "'")
+if [[ "$OMAKUB_THEME_PEFER" == "prefer-dark" ]]; then
+    OMAKUB_THEME_SUFFIX="-Dark"
+fi
+
+OMAKUB_THEME_FONTANDSIZE='"'$(gsettings get org.gnome.desktop.interface font-name | tr -d "'" | awk '{
+    size = $NF;
+    name = "";
+    for (i = 1; i < NF; i++) {
+        if (i > 1) name = name " ";
+        name = name $i;
+    }
+    print name "," size;
+}')'"'
+OMAKUB_THEME_FONTANDSIZE_MONO='"'$(gsettings get org.gnome.desktop.interface monospace-font-name | tr -d "'" | awk '{
+    size = $NF;
+    name = "";
+    for (i = 1; i < NF; i++) {
+        if (i > 1) name = name " ";
+        name = name $i;
+    }
+    print name "," size;
+}')'"'
+
+printf "%s\n" \
+    "[Appearance]" \
+    "custom_palette=false" \
+    "icon_theme=Yaru$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")" \
+    "standard_dialogs=gtk3" \
+    "style=Adwaita${OMAKUB_THEME_SUFFIX}" \
+    "" \
+    "[Fonts]" \
+    "general=$OMAKUB_THEME_FONTANDSIZE" \
+    "fixed=$OMAKUB_THEME_FONTANDSIZE_MONO" \
+    "" |
+    tee ~/.config/qt6ct/qt6ct.conf >/dev/null

--- a/themes/set-qt6-theme.sh
+++ b/themes/set-qt6-theme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-mkdir -p ~/.config/qt5ct ~/.config/qt6ct
+mkdir -p ~/.config/qt6ct
 OMAKUB_THEME_PEFER=$(gsettings get org.gnome.desktop.interface color-scheme | tr -d "'")
 if [[ "$OMAKUB_THEME_PEFER" == "prefer-dark" ]]; then
     OMAKUB_THEME_SUFFIX="-Dark"

--- a/themes/tokyo-night/gnome.sh
+++ b/themes/tokyo-night/gnome.sh
@@ -4,4 +4,4 @@ OMAKUB_THEME_PEFER="dark"
 OMAKUB_THEME_STYLE="purple"
 OMAKUB_THEME_ACCENT=("purple")
 OMAKUB_THEME_BACKGROUND="tokyo-night/background.jpg"
-source "$OMAKUB_PATH"/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH/themes/set-gnome-theme.sh"

--- a/themes/tokyo-night/gnome.sh
+++ b/themes/tokyo-night/gnome.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-OMAKUB_THEME_COLOR="purple"
+OMAKUB_THEME_PEFER="dark"
+OMAKUB_THEME_STYLE="purple"
+OMAKUB_THEME_ACCENT=("purple")
 OMAKUB_THEME_BACKGROUND="tokyo-night/background.jpg"
-source $OMAKUB_PATH/themes/set-gnome-theme.sh
+source "$OMAKUB_PATH"/themes/set-gnome-theme.sh

--- a/themes/tokyo-night/tophat.sh
+++ b/themes/tokyo-night/tophat.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"


### PR DESCRIPTION
A few clarifications are probably needed here.
First, Ubuntu has its own set of accent colors. If themes are carelessly transferred from Omarchy, not all of them will work as intended. Second, Ubuntu also has its own set of Yaru themes, two of which are simply missing for some reason.
Now, to fix all this, I suggest downloading the missing set from Debian. Second, don't just use a specific accent color, but a set of the most similar ones.

As for Tophat, it didn't work! The checkbox there should have been unchecked by default. But what's the point of unchecking it if we're fixing the accent color?

Now, regarding QT themes, you can, and in my opinion, you should style them to match the main theme. Which is what I do.

Regarding fonts, again, when installing a font, the size was reset, which is illogical, and when selecting a size, it only affected Alacritty, which is illogical.