### PR TITLE
Adjusted package upgrade to include phased packages to avoid flatpak error

### DIFF
--- a/install/terminal.sh
+++ b/install/terminal.sh
@@ -2,7 +2,7 @@
 
 # Needed for all installers
 sudo apt update -y
-sudo apt upgrade -y
+sudo apt -o APT::Get::Always-Include-Phased-Updates=true dist-upgrade -y
 sudo apt install -y curl git unzip
 
 # Run terminal installers


### PR DESCRIPTION
- Ubuntu 25.10 (Questing Quokka) latest ISO still includes a bug that prevents flatpak installs, detailed here: https://bugs.launchpad.net/ubuntu/+source/flatpak/+bug/2122161
- This bug has the effect that the Omakub installation fails upon trying to install a flatpak
- A fix exists in the latest apparmor package (5.0.0~alpha1-0ubuntu8.3) resolving fusermount3 denials and is listed in the apparmor changelog
- However, Omakub terminal.sh file calls "sudo apt upgrade -y" which does not currently upgrade to latest apparmor package (since its phased)
- This pull request includes a change to the Omakub terminal.sh file upgrade line to temporarily upgrade using phased package releases, thus making the flatpak install fix available prior to flatpaks being used in Omakub install process
