### PR TITLE
Fix cursor disappearing on Alacritty

### DIFF
--- a/configs/bashrc
+++ b/configs/bashrc
@@ -3,3 +3,6 @@ source ~/.local/share/omakub/defaults/bash/rc
 # Editor used by CLI
 export EDITOR="nvim"
 export SUDO_EDITOR="$EDITOR"
+
+# Fix cursor on Alacritty
+export XCURSOR_THEME=Yaru


### PR DESCRIPTION
As suggested in [this issue](https://github.com/basecamp/omakub/issues/561), I've integrated this ENV variable to force the cursor on the Alacritty terminal. We don't need the SIZE, just the THEME.

Fix #561 