### PR TITLE
fix: add migration to remove orphaned open-alacritty.py extension

### DIFF
--- a/migrations/1766474461.sh
+++ b/migrations/1766474461.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Remove orphaned open-alacritty.py Nautilus extension
+# This extension was introduced in PR #435 and removed in PR #559,
+# but the installed file was never cleaned up for existing users.
+# The extension had a bug causing Nautilus context menu to freeze
+# due to blocking os.system() call.
+
+if [ -f ~/.local/share/nautilus-python/extensions/open-alacritty.py ]; then
+    rm -f ~/.local/share/nautilus-python/extensions/open-alacritty.py
+    rm -rf ~/.local/share/nautilus-python/extensions/__pycache__
+
+    # Restart Nautilus to apply changes (if running)
+    nautilus -q 2>/dev/null || true
+fi


### PR DESCRIPTION
## Summary

- Adds migration script to remove the orphaned `open-alacritty.py` Nautilus extension

## Problem

The "Open in Alacritty" Nautilus extension was introduced in PR #435 and later removed in PR #559 (Ubuntu 25.10 compatibility). However, users who installed Omakub between these two PRs still have the extension file at:

```
~/.local/share/nautilus-python/extensions/open-alacritty.py
```

This extension has a bug where it uses a **blocking** `os.system("alacritty")` call, causing the Nautilus right-click context menu to freeze/hang until Alacritty is closed.

## Solution

This PR adds a migration script that:
1. Removes the orphaned `open-alacritty.py` file (if it exists)
2. Clears the `__pycache__` directory
3. Restarts Nautilus to apply changes

## Test plan

- [x] Verified migration script runs without errors
- [x] Confirmed extension file is removed after migration
- [x] Context menu no longer freezes after fix

## Related

- PR #435 - Introduced the extension
- PR #559 - Removed the extension from install script (but not cleanup)