### PR TITLE
Ubuntu 26.04 Compatibility

### DIFF
--- a/bin/omakub-sub/manual.sh
+++ b/bin/omakub-sub/manual.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-xdg-open "https://manual.omakub.org" &>/dev/null
+xdg-open "https://learn.omacom.io/1/read" &>/dev/null
 source $OMAKUB_PATH/bin/omakub-sub/menu.sh

--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,9 @@ if [[ "$XDG_CURRENT_DESKTOP" == *"GNOME"* ]]; then
   # Revert to normal idle and lock settings
   gsettings set org.gnome.desktop.screensaver lock-enabled true
   gsettings set org.gnome.desktop.session idle-delay 300
+
+  # Finish up with a reboot prompt to ensure all settings take effect
+  source ~/.local/share/omakub/install/finished.sh
 else
   echo "Only installing terminal tools..."
   source ~/.local/share/omakub/install/terminal.sh

--- a/install/desktop.sh
+++ b/install/desktop.sh
@@ -2,6 +2,3 @@
 
 # Run desktop installers
 for installer in ~/.local/share/omakub/install/desktop/*.sh; do source $installer; done
-
-# Logout to pickup changes
-gum confirm "Ready to reboot for all settings to take effect?" && sudo reboot || true

--- a/install/desktop/optional/app-asdcontrol.sh
+++ b/install/desktop/optional/app-asdcontrol.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 # Install asdcontrol
-git clone https://github.com/omakasui/asdcontrol.git /tmp/asdcontrol
-cd /tmp/asdcontrol
-make
-sudo make install
+ASDCONTROL_VERSION=$(curl -s https://api.github.com/repos/omakasui/asdcontrol/releases/latest | grep -Po '"tag_name": "v\K[^"]*')
+wget -O asdcontrol.deb "https://github.com/omakasui/asdcontrol/releases/latest/download/asdcontrol_${ASDCONTROL_VERSION}_amd64.deb"
+sudo apt install -y ./asdcontrol.deb
+rm asdcontrol.deb
 cd -
-rm -rf /tmp/asdcontrol
 
 # Setup sudo-less controls
 echo 'KERNEL=="hiddev*", ATTRS{idVendor}=="05ac", ATTRS{idProduct}=="9243", GROUP="users", OWNER="root", MODE="0660"' | sudo tee /etc/udev/rules.d/50-apple-xdr.rules >/dev/null

--- a/install/desktop/optional/app-asdcontrol.sh
+++ b/install/desktop/optional/app-asdcontrol.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Install asdcontrol
+cd /tmp
 ASDCONTROL_VERSION=$(curl -s https://api.github.com/repos/omakasui/asdcontrol/releases/latest | grep -Po '"tag_name": "v\K[^"]*')
 wget -O asdcontrol.deb "https://github.com/omakasui/asdcontrol/releases/latest/download/asdcontrol_${ASDCONTROL_VERSION}_amd64.deb"
 sudo apt install -y ./asdcontrol.deb

--- a/install/desktop/optional/app-asdcontrol.sh
+++ b/install/desktop/optional/app-asdcontrol.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install asdcontrol
-git clone https://github.com/nikosdion/asdcontrol.git /tmp/asdcontrol
+git clone https://github.com/omakasui/asdcontrol.git /tmp/asdcontrol
 cd /tmp/asdcontrol
 make
 sudo make install

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -22,12 +22,16 @@ gext install tophat@fflewddur.github.io
 gext install AlphabeticalAppGrid@stuarthayhurst
 
 # Compile gsettings schemas in order to be able to set them
-sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp -rf ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
 
 # Configure Tactile

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -22,19 +22,19 @@ gext install tophat@fflewddur.github.io
 gext install AlphabeticalAppGrid@stuarthayhurst
 
 # Compile gsettings schemas in order to be able to set them
-sudo cp -rf ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
 if [ -f ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml ]; then
-    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
+  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
 else
-    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
-    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
-    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
-    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
+  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
+  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
+  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
+  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
 fi
-sudo cp -rf ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
 
 # Configure Tactile

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -25,11 +25,14 @@ gext install AlphabeticalAppGrid@stuarthayhurst
 sudo cp -rf ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp -rf ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp -rf ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
+if [ -f ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml ]; then
+    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
+else
+    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
+    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
+    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
+    sudo cp -rf ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
+fi
 sudo cp -rf ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp -rf ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas/

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -28,10 +28,13 @@ sudo cp ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.
 if [ -f ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml ]; then
   sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
 else
-  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
-  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
-  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
-  sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
+  space_bar_schema_glob=~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.*.gschema.xml
+  if ls $space_bar_schema_glob >/dev/null 2>&1; then
+    sudo cp $space_bar_schema_glob /usr/share/glib-2.0/schemas/
+  else
+    echo "Error: No Space Bar schema files were found under ~/.local/share/gnome-shell/extensions/space-bar@luchrioh/schemas/" >&2
+    exit 1
+  fi
 fi
 sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/

--- a/install/finished.sh
+++ b/install/finished.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Logout to pickup changes
+gum confirm "Ready to reboot for all settings to take effect?" && sudo systemctl reboot -i || true

--- a/install/finished.sh
+++ b/install/finished.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# Logout to pickup changes
+# Reboot to pick up changes
 gum confirm "Ready to reboot for all settings to take effect?" && sudo systemctl reboot -i || true

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -26,12 +26,17 @@ install_php() {
     xml
     zip
   )
+  local available_extensions=()
 
   for extension in "${extensions_to_install[@]}"; do
     if apt-cache show "php-$extension" &>/dev/null; then
-        sudo apt-get install -y "php-$extension" --no-install-recommends
+      available_extensions+=("php-$extension")
     fi
   done
+
+  if [[ ${#available_extensions[@]} -gt 0 ]]; then
+    sudo apt-get install -y --no-install-recommends "${available_extensions[@]}"
+  fi
 }
 
 if [[ -n "$languages" ]]; then

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -35,7 +35,7 @@ install_php() {
 
   # Install Composer globally
   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-  php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
+  php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer && sudo chmod +x /usr/local/bin/composer
   rm composer-setup.php
 }
 

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -8,38 +8,78 @@ else
   languages=$(gum choose "${AVAILABLE_LANGUAGES[@]}" --no-limit --height 10 --header "Select programming languages")
 fi
 
+install_php() {
+  echo -e "Installing PHP...\n"
+  sudo apt -y install php --no-install-recommends
+
+  # Install commonly used PHP extensions if available
+  local extensions_to_install=(
+    curl
+    apcu
+    intl
+    mbstring
+    opcache
+    pgsql
+    mysql
+    sqlite3
+    redis
+    xml
+    zip
+  )
+
+  for extension in "${extensions_to_install[@]}"; do
+    if apt-cache show "php-$extension" &>/dev/null; then
+        sudo apt-get install -y "php-$extension" --no-install-recommends
+    fi
+  done
+
+  # Install Composer globally
+  php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+  php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
+  rm composer-setup.php
+}
+
 if [[ -n "$languages" ]]; then
   for language in $languages; do
     case $language in
     Ruby)
-      mise use --global ruby@latest
+      echo -e "Installing Ruby on Rails...\n"
+      mise settings add ruby.compile false
       mise settings add idiomatic_version_file_enable_tools ruby
+      mise use --global ruby@latest
+      echo "gem: --no-document" >~/.gemrc
       mise x ruby -- gem install rails --no-document
+      echo -e "\nYou can now run: rails new myproject"
       ;;
     Node.js)
-      mise use --global node@lts
+      echo -e "Installing Node.js...\n"
+      mise use --global node
       ;;
     Go)
+      echo -e "Installing Go...\n"
       mise use --global go@latest
       ;;
     PHP)
-      sudo apt -y install php php-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip} --no-install-recommends
-      php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-      php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer
-      rm composer-setup.php
+      install_php
       ;;
     Python)
+      echo -e "Installing Python...\n"
       mise use --global python@latest
+      echo -e "\nInstalling uv...\n"
+      curl -fsSL https://astral.sh/uv/install.sh | sh
       ;;
     Elixir)
+      echo -e "Installing Elixir...\n"
       mise use --global erlang@latest
       mise use --global elixir@latest
       mise x elixir -- mix local.hex --force
       ;;
     Rust)
+      echo -e "Installing Rust...\n"
       bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y
       ;;
     Java)
+      echo -e "Installing Java...\n"
       mise use --global java@latest
       ;;
     esac

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -67,7 +67,7 @@ if [[ -n "$languages" ]]; then
       echo -e "Installing Python...\n"
       mise use --global python@latest
       echo -e "\nInstalling uv...\n"
-      curl -fsSL https://astral.sh/uv/install.sh | sh
+      mise use -global uv@latest
       ;;
     "Elixir")
       echo -e "Installing Elixir...\n"

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -40,9 +40,10 @@ install_php() {
 }
 
 if [[ -n "$languages" ]]; then
-  for language in $languages; do
+  mapfile -t selected_languages <<< "$languages"
+  for language in "${selected_languages[@]}"; do
     case $language in
-    Ruby)
+    "Ruby on Rails")
       echo -e "Installing Ruby on Rails...\n"
       mise settings add ruby.compile false
       mise settings add idiomatic_version_file_enable_tools ruby
@@ -51,34 +52,34 @@ if [[ -n "$languages" ]]; then
       mise x ruby -- gem install rails --no-document
       echo -e "\nYou can now run: rails new myproject"
       ;;
-    Node.js)
+    "Node.js")
       echo -e "Installing Node.js...\n"
       mise use --global node
       ;;
-    Go)
+    "Go")
       echo -e "Installing Go...\n"
       mise use --global go@latest
       ;;
-    PHP)
+    "PHP")
       install_php
       ;;
-    Python)
+    "Python")
       echo -e "Installing Python...\n"
       mise use --global python@latest
       echo -e "\nInstalling uv...\n"
       curl -fsSL https://astral.sh/uv/install.sh | sh
       ;;
-    Elixir)
+    "Elixir")
       echo -e "Installing Elixir...\n"
       mise use --global erlang@latest
       mise use --global elixir@latest
       mise x elixir -- mix local.hex --force
       ;;
-    Rust)
+    "Rust")
       echo -e "Installing Rust...\n"
       bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs)" -- -y
       ;;
-    Java)
+    "Java")
       echo -e "Installing Java...\n"
       mise use --global java@latest
       ;;

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -36,7 +36,7 @@ install_php() {
   # Install Composer globally
   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
   php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer && sudo chmod +x /usr/local/bin/composer
-  rm composer-setup.php
+  rm -f composer-setup.php
 }
 
 if [[ -n "$languages" ]]; then

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -10,7 +10,7 @@ fi
 
 install_php() {
   echo -e "Installing PHP...\n"
-  sudo apt-get -y install php --no-install-recommends
+  sudo apt-get -y install php composer --no-install-recommends
 
   # Install commonly used PHP extensions if available
   local extensions_to_install=(
@@ -32,11 +32,6 @@ install_php() {
         sudo apt-get install -y "php-$extension" --no-install-recommends
     fi
   done
-
-  # Install Composer globally
-  php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-  php composer-setup.php --quiet && sudo mv composer.phar /usr/local/bin/composer && sudo chmod +x /usr/local/bin/composer
-  rm -f composer-setup.php
 }
 
 if [[ -n "$languages" ]]; then

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -29,7 +29,10 @@ install_php() {
   local available_extensions=()
 
   for extension in "${extensions_to_install[@]}"; do
-    if apt-cache show "php-$extension" &>/dev/null; then
+    local candidate
+    candidate=$(apt-cache policy "php-$extension" 2>/dev/null | awk '/Candidate:/ {print $2}')
+
+    if [[ -n "$candidate" && "$candidate" != "(none)" ]]; then
       available_extensions+=("php-$extension")
     fi
   done

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -67,7 +67,7 @@ if [[ -n "$languages" ]]; then
       echo -e "Installing Python...\n"
       mise use --global python@latest
       echo -e "\nInstalling uv...\n"
-      mise use -global uv@latest
+      mise use --global uv@latest
       ;;
     "Elixir")
       echo -e "Installing Elixir...\n"

--- a/install/terminal/select-dev-language.sh
+++ b/install/terminal/select-dev-language.sh
@@ -10,7 +10,7 @@ fi
 
 install_php() {
   echo -e "Installing PHP...\n"
-  sudo apt -y install php --no-install-recommends
+  sudo apt-get -y install php --no-install-recommends
 
   # Install commonly used PHP extensions if available
   local extensions_to_install=(

--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -17,7 +17,6 @@ if [[ -n "$languages" ]]; then
       mise uninstall ruby --all
       mise rm -g ruby
       rm -f ~/.gemrc
-
       ;;
     "Node.js")
       echo -e "Removing Node.js...\n"

--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -37,7 +37,6 @@ if [[ -n "$languages" ]]; then
         sudo apt-get remove -y php composer
       fi
       sudo apt-get autoremove -y
-      sudo rm -f /usr/local/bin/composer
       ;;
     "Python")
       echo -e "Removing Python...\n"

--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -14,41 +14,53 @@ if [[ -n "$languages" ]]; then
     case $language in
     "Ruby on Rails")
       echo -e "Removing Ruby on Rails...\n"
-      mise uninstall -g ruby@latest
-      mise settings remove idiomatic_version_file_enable_tools ruby
-      mise x ruby -- gem uninstall rails --all --ignore-dependencies --no-document
+      mise uninstall ruby --all
+      mise rm -g ruby
+      rm -f ~/.gemrc
 
       ;;
     "Node.js")
       echo -e "Removing Node.js...\n"
-      mise uninstall -g node@lts
+      mise uninstall node --all
+      mise rm -g node
       ;;
     "Go")
       echo -e "Removing Go...\n"
-      mise uninstall -g go@latest
+      mise uninstall go --all
+      mise rm -g go
       ;;
     "PHP")
       echo -e "Removing PHP...\n"
-      sudo apt-get remove -y php php-* composer
+      mapfile -t php_packages < <(dpkg-query -W -f='${binary:Package}\n' 'php-*' 2>/dev/null || true)
+      if ((${#php_packages[@]})); then
+        sudo apt-get remove -y php "${php_packages[@]}" composer
+      else
+        sudo apt-get remove -y php composer
+      fi
       sudo apt-get autoremove -y
       sudo rm -f /usr/local/bin/composer
       ;;
     "Python")
       echo -e "Removing Python...\n"
-      mise uninstall -g python@latest
+      mise uninstall python --all
+      mise rm -g python
+      rm -rf ~/.local/bin/uv ~/.local/bin/uvx ~/.cargo/bin/uv 2>/dev/null || true
       ;;
     "Elixir")
       echo -e "Removing Elixir...\n"
-      mise uninstall -g elixir@latest
-      mise uninstall -g erlang@latest
+      mise uninstall elixir --all
+      mise uninstall erlang --all
+      mise rm -g elixir
+      mise rm -g erlang
       ;;
     "Rust")
       echo -e "Removing Rust...\n"
-      rustup self uninstall -y
+      rustup self uninstall -y 2>/dev/null || true
       ;;
     "Java")
       echo -e "Removing Java...\n"
-      mise uninstall -g java@latest
+      mise uninstall java --all
+      mise rm -g java
       ;;
     esac
   done

--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -36,6 +36,7 @@ if [[ -n "$languages" ]]; then
       else
         sudo apt-get remove -y php composer
       fi
+      sudo rm -f /usr/local/bin/composer
       sudo apt-get autoremove -y
       ;;
     "Python")

--- a/uninstall/dev-language.sh
+++ b/uninstall/dev-language.sh
@@ -8,36 +8,47 @@ else
   languages=$(gum choose "${AVAILABLE_LANGUAGES[@]}" --no-limit --height 10 --header "Select programming languages to uninstall")
 fi
 
-if [[ -n $languages ]]; then
-  for language in $languages; do
+if [[ -n "$languages" ]]; then
+  mapfile -t selected_languages <<< "$languages"
+  for language in "${selected_languages[@]}"; do
     case $language in
-    Ruby)
-      mise uninstall ruby@3.4
-      mise x ruby -- gem uninstall rails
+    "Ruby on Rails")
+      echo -e "Removing Ruby on Rails...\n"
+      mise uninstall -g ruby@latest
+      mise settings remove idiomatic_version_file_enable_tools ruby
+      mise x ruby -- gem uninstall rails --all --ignore-dependencies --no-document
+
       ;;
-    Node.js)
-      mise uninstall node@lts
+    "Node.js")
+      echo -e "Removing Node.js...\n"
+      mise uninstall -g node@lts
       ;;
-    Go)
-      mise uninstall go@latest
+    "Go")
+      echo -e "Removing Go...\n"
+      mise uninstall -g go@latest
       ;;
-    PHP)
-      sudo apt -y purge php php-{curl,apcu,intl,mbstring,opcache,pgsql,mysql,sqlite3,redis,xml,zip}
-      sudo apt -y autoremove
-      sudo rm /usr/local/bin/composer
+    "PHP")
+      echo -e "Removing PHP...\n"
+      sudo apt-get remove -y php php-* composer
+      sudo apt-get autoremove -y
+      sudo rm -f /usr/local/bin/composer
       ;;
-    Python)
-      mise uninstall python@latest
+    "Python")
+      echo -e "Removing Python...\n"
+      mise uninstall -g python@latest
       ;;
-    Elixir)
-      mise uninstall elixir@latest
-      mise uninstall erlang@latest
+    "Elixir")
+      echo -e "Removing Elixir...\n"
+      mise uninstall -g elixir@latest
+      mise uninstall -g erlang@latest
       ;;
-    Rust)
+    "Rust")
+      echo -e "Removing Rust...\n"
       rustup self uninstall -y
       ;;
-    Java)
-      mise uninstall java@latest
+    "Java")
+      echo -e "Removing Java...\n"
+      mise uninstall -g java@latest
       ;;
     esac
   done


### PR DESCRIPTION
This PR includes the main adjustments required to ensure Omakub installs and runs properly on Ubuntu 26.04.

## What's Changed

### Changed
* Separate reboot request from `dekstop.sh` and put after no-sleep restore
* Reboot now uses systemctl for better compatibility 
* Massive update for installing and removing dev languages scripts
* Used fork `omakasui/asdcontrol` instead of `nikosdion/asdcontrol` as it was archived
* Added compatibility with new SpaceBar schemas

### Fixed
* Fixed link to Omakub manual
