### PR TITLE
Fork Omakub for Kali Linux 2025.1+ GNOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,36 @@
-# Omakub
+# Omakub (Kali Linux edition)
 
-Turn a fresh Ubuntu installation into a fully-configured, beautiful, and modern web development system by running a single command. That's the one-line pitch for Omakub. No need to write bespoke configs for every essential tool just to get started or to be up on all the latest command-line tools. Omakub is an opinionated take on what Linux can be at its best.
+Turn a fresh **Kali Linux 2025.1+ GNOME** installation into a fully-configured, beautiful, and modern web development system by running a single command. This is a Kali-only fork of the upstream Ubuntu Omakub project. No need to write bespoke configs for every essential tool just to get started or to be up on all the latest command-line tools. Omakub is an opinionated take on what Linux can be at its best.
 
-Watch the introduction video and read more at [omakub.org](https://omakub.org).
+Watch the upstream introduction video and read more at [omakub.org](https://omakub.org).
 
-## Contributing to the documentation
+## Install
 
-Please help us improve Omakub's documentation on the [basecamp/omakub-site repository](https://github.com/basecamp/omakub-site).
+### From a local checkout (recommended for this fork)
+
+```bash
+bash ~/Desktop/omakub/setup-local.sh
+```
+
+`setup-local.sh` symlinks the checkout into `~/.local/share/omakub` (where every installer expects to live) and then runs the full install. Works regardless of which directory you cloned to.
+
+### From a remote clone (after you push your fork)
+
+```bash
+OMAKUB_REPO=https://github.com/<you>/omakub.git bash -c "$(curl -fsSL https://raw.githubusercontent.com/<you>/omakub/master/boot.sh)"
+```
+
+## What's different from upstream
+
+| Upstream (Ubuntu)              | This fork (Kali)                                  |
+|--------------------------------|---------------------------------------------------|
+| `ID=ubuntu`, `VERSION_ID>=24.04` gate | `ID=kali` (rolling, 2025.1+ recommended)   |
+| Docker repo `linux/ubuntu`     | Docker repo `linux/debian` pinned to `bookworm`   |
+| fastfetch via PPA              | fastfetch from Kali rolling repo                  |
+| ulauncher via PPA              | ulauncher from apt with GitHub `.deb` fallback    |
+| Disables `*@ubuntu.com` GNOME extensions | Disables `pop-shell` + `ding` (Kali defaults) |
+| Optional: Mainline Kernels (PPA) | Removed (Kali is a rolling distro)              |
+| Optional editor: RubyMine (snap) | Removed (no snap on Kali)                       |
 
 ## License
 

--- a/applications/About.sh
+++ b/applications/About.sh
@@ -8,7 +8,7 @@ Comment=System information from Fastfetch
 Exec=alacritty --config-file /home/$USER/.config/alacritty/pane.toml --class=About --title=About -e bash -c 'fastfetch; read -n 1 -s'
 Terminal=false
 Type=Application
-Icon=/home/$USER/.local/share/omakub/applications/icons/Ubuntu.png
+Icon=kali-menu
 Categories=GTK;
 StartupNotify=false
 EOF

--- a/bin/omakub-sub/install-dev-editor.sh
+++ b/bin/omakub-sub/install-dev-editor.sh
@@ -3,7 +3,6 @@
 CHOICES=(
   "Cursor            AI Code Editor"
   "Doom Emacs        Emacs framework with curated list of packages"
-  "RubyMine          IntelliJ's commercial Ruby editor"
   "Windsurf          Another AI Code Editor"
   "Zed               Fast all-purpose editor"
   "<< Back           "

--- a/bin/omakub-sub/install.sh
+++ b/bin/omakub-sub/install.sh
@@ -12,7 +12,6 @@ CHOICES=(
   "Discord           Communication platform for voice, video, and text messaging"
   "Gimp              Image manipulation tool ala Photoshop"
   "Geekbench         CPU benchmaking tool"
-  "Mainline Kernels  Install newer Linux kernels than Ubuntu defaults"
   "Minecraft         Everyone's favorite blocky building game"
   "OBS Studio        Record screencasts with inputs from both display + webcam"
   "Ollama            Run LLMs, like Meta's Llama3, locally"

--- a/boot.sh
+++ b/boot.sh
@@ -11,15 +11,19 @@ ascii_art='________                  __        ___.
 '
 
 echo -e "$ascii_art"
-echo "=> Omakub is for fresh Ubuntu 24.04+ installations only!"
+echo "=> Omakub is for fresh Kali Linux 2025.1+ GNOME installations only!"
+echo "   (For installing from a local checkout instead of cloning, use setup-local.sh.)"
 echo -e "\nBegin installation (or abort with ctrl+c)..."
 
 sudo apt-get update >/dev/null
 sudo apt-get install -y git >/dev/null
 
-echo "Cloning Omakub..."
+# Set OMAKUB_REPO to your own fork (e.g. https://github.com/youruser/omakub.git) if you forked.
+OMAKUB_REPO="${OMAKUB_REPO:-https://github.com/basecamp/omakub.git}"
+
+echo "Cloning Omakub from $OMAKUB_REPO..."
 rm -rf ~/.local/share/omakub
-git clone https://github.com/basecamp/omakub.git ~/.local/share/omakub >/dev/null
+git clone "$OMAKUB_REPO" ~/.local/share/omakub >/dev/null
 if [[ $OMAKUB_REF != "master" ]]; then
 	cd ~/.local/share/omakub
 	git fetch origin "${OMAKUB_REF:-stable}" && git checkout "${OMAKUB_REF:-stable}"

--- a/defaults/bash/functions
+++ b/defaults/bash/functions
@@ -13,7 +13,7 @@ webm2mp4() {
 iso2sd() {
   if [ $# -ne 2 ]; then
     echo "Usage: iso2sd <input_file> <output_device>"
-    echo "Example: iso2sd ~/Downloads/ubuntu-25.04-desktop-amd64.iso /dev/sda"
+    echo "Example: iso2sd ~/Downloads/kali-linux-2026.1-installer-amd64.iso /dev/sda"
     echo -e "\nAvailable SD cards:"
     lsblk -d -o NAME | grep -E '^sd[a-z]' | awk '{print "/dev/"$1}'
   else

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,15 @@ set -e
 # Give people a chance to retry running the installation
 trap 'echo "Omakub installation failed! You can retry by running: source ~/.local/share/omakub/install.sh"' ERR
 
+# Refuse to run via sudo. See setup-local.sh for the rationale; running as
+# root corrupts $HOME-based paths and disconnects us from the user GNOME
+# session bus that gext needs.
+if [ -n "$SUDO_USER" ] && [ "$EUID" -eq 0 ]; then
+  echo "$(tput setaf 1)Error: Do not run Omakub with sudo." >&2
+  echo "Run as your normal (non-root) user; the installer will sudo when needed." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
 # Check the distribution name and version and abort if incompatible
 source ~/.local/share/omakub/install/check-version.sh
 

--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -8,13 +8,20 @@ fi
 
 . /etc/os-release
 
-# Check if running on Ubuntu 24.04 or higher
-if [ "$ID" != "ubuntu" ] || [ $(echo "$VERSION_ID >= 24.04" | bc) != 1 ]; then
+# Check if running on Kali Linux
+if [ "$ID" != "kali" ]; then
   echo "$(tput setaf 1)Error: OS requirement not met"
   echo "You are currently running: $ID $VERSION_ID"
-  echo "OS required: Ubuntu 24.04 or higher"
+  echo "OS required: Kali Linux (rolling, 2025.1 or higher recommended)"
   echo "Installation stopped."
   exit 1
+fi
+
+# Soft-warn if version looks old (Kali rolling; sort -V handles 2026.1 vs 2025.1)
+MIN_VERSION="2025.1"
+if [ -n "$VERSION_ID" ] && [ "$(printf '%s\n%s\n' "$MIN_VERSION" "$VERSION_ID" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
+  echo "$(tput setaf 3)Warning: Detected $ID $VERSION_ID; $MIN_VERSION or newer is recommended."
+  echo "Run 'sudo apt update && sudo apt full-upgrade -y' before continuing if you hit issues."
 fi
 
 # Check if running on x86

--- a/install/desktop/app-vscode.sh
+++ b/install/desktop/app-vscode.sh
@@ -16,5 +16,12 @@ sudo apt install -y code
 mkdir -p ~/.config/Code/User
 cp ~/.local/share/omakub/configs/vscode.json ~/.config/Code/User/settings.json
 
-# Install default supported themes
-code --install-extension enkia.tokyo-night
+# Install default supported themes.
+#   --disable-telemetry: VS Code's CLI otherwise flushes pending telemetry POSTs
+#     to mobile.events.data.microsoft.com on exit. If that endpoint is slow or
+#     blocked (privacy DNS, firewalls, offline networks), the install hangs
+#     indefinitely. See logs at ~/.config/Code/logs/*/cli.log.
+#   timeout: hard ceiling so a network hiccup can never wedge the installer.
+#   || true: a failed theme install shouldn't abort the whole omakub run.
+timeout 180 code --install-extension catppuccin.catppuccin-vsc --disable-telemetry || \
+  echo "Warning: VS Code extension install failed or timed out; continuing."

--- a/install/desktop/optional/app-brave.sh
+++ b/install/desktop/optional/app-brave.sh
@@ -4,7 +4,7 @@ if [ ! -f /etc/apt/sources.list.d/brave-browser-release.list ]; then
   [ -f /usr/share/keyrings/brave-browser-archive-keyring.gpg ] && sudo rm /usr/share/keyrings/brave-browser-archive-keyring.gpg
   sudo curl -fsSLo /usr/share/keyrings/brave-browser-archive-keyring.gpg https://brave-browser-apt-release.s3.brave.com/brave-browser-archive-keyring.gpg
   echo "deb [signed-by=/usr/share/keyrings/brave-browser-archive-keyring.gpg arch=amd64] https://brave-browser-apt-release.s3.brave.com/ stable main" | sudo tee /etc/apt/sources.list.d/brave-browser-release.list
-fi
+if
 
 sudo apt update
 sudo apt install -y brave-browser

--- a/install/desktop/optional/app-mainline-kernels.sh
+++ b/install/desktop/optional/app-mainline-kernels.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-sudo add-apt-repository -y ppa:cappelikan/ppa
-sudo apt update -y
-sudo apt install -y mainline

--- a/install/desktop/optional/app-rubymine.sh
+++ b/install/desktop/optional/app-rubymine.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sudo snap install rubymine --classic

--- a/install/desktop/set-app-grid.sh
+++ b/install/desktop/set-app-grid.sh
@@ -8,7 +8,6 @@ sudo rm -rf /usr/share/applications/org.flameshot.Flameshot.desktop
 
 # Remove the ImageMagick icon
 sudo rm -rf /usr/share/applications/display-im6.q16.desktop
-sudo rm -rf /usr/share/applications/display-im7.q16.desktop
 
 # Replacing this with btop
 sudo rm -rf /usr/share/applications/org.gnome.SystemMonitor.desktop
@@ -22,7 +21,7 @@ gsettings set org.gnome.desktop.app-folders folder-children "['Utilities', 'Sund
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Updates/ name 'Install & Update'
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Updates/ apps "['org.gnome.Software.desktop', 'software-properties-drivers.desktop', 'software-properties-gtk.desktop', 'update-manager.desktop', 'firmware-updater_firmware-updater.desktop', 'snap-store_snap-store.desktop']"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Xtra/ name 'Xtra'
-gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Xtra/ apps "['org.Characters.desktop', 'gnome-language-selector.desktop', 'org.gnome.PowerStats.desktop', 'org.gnome.Logs.desktop', 'yelp.desktop', 'org.gnome.Yelp.desktop', 'org.gnome.eog.desktop', 'org.gnome.Sysprof.desktop' ]"
+gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Xtra/ apps "['gnome-language-selector.desktop', 'org.gnome.PowerStats.desktop', 'yelp.desktop', 'org.gnome.eog.desktop']"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/LibreOffice/ name 'LibreOffice'
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/LibreOffice/ apps "['libreoffice-base.desktop', 'libreoffice-calc.desktop', 'libreoffice-draw.desktop', 'libreoffice-impress.desktop', 'libreoffice-math.desktop', 'libreoffice-startcenter.desktop', 'libreoffice-writer.desktop', 'libreoffice-xsltfilter.desktop']"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/WebApps/ name 'Web Apps'

--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -1,13 +1,34 @@
 #!/bin/bash
 
-sudo apt install -y gnome-shell-extension-manager gir1.2-gtop-2.0 gir1.2-clutter-1.0
+sudo apt install -y gnome-shell-extension-manager gir1.2-gtop-2.0 gir1.2-clutter-1.0 libglib2.0-bin
 pipx install gnome-extensions-cli --system-site-packages
 
-# Turn off default Ubuntu extensions
-gnome-extensions disable tiling-assistant@ubuntu.com
-gnome-extensions disable ubuntu-appindicators@ubuntu.com
-gnome-extensions disable ubuntu-dock@ubuntu.com
-gnome-extensions disable ding@rastersoft.com
+# gext (gnome-extensions-cli) drives extension install over the session DBus.
+# If GNOME Shell isn't running on this user's session bus, we'd flood the log
+# with "org.gnome.Shell ServiceUnknown" errors and then poison every gsettings
+# call with "No such schema". This happens when:
+#   - the installer was launched outside a GNOME graphical session
+#     (over SSH, from a TTY, or as a different user via sudo/su), or
+#   - GNOME Shell hasn't started yet (e.g. running before first GNOME login).
+# In any of those cases, skip extension install entirely. The user can re-run
+# `source ~/.local/share/omakub/install/desktop/set-gnome-extensions.sh`
+# (or just `omakub` from the menu) from a real GNOME-session terminal.
+if ! command -v gdbus >/dev/null 2>&1 || \
+   ! gdbus introspect --session --dest org.gnome.Shell \
+       --object-path /org/gnome/Shell >/dev/null 2>&1; then
+  echo "$(tput setaf 3)Warning: GNOME Shell is not reachable on this session bus."
+  echo "Skipping GNOME extension install/configure."
+  echo "Log in to GNOME as your normal user, open a Terminal, and re-run:"
+  echo "  source ~/.local/share/omakub/install/desktop/set-gnome-extensions.sh"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Disable preinstalled extensions that conflict with what Omakub installs.
+# Kali GNOME ships pop-shell tiling and may include ding desktop icons; both are
+# replaced/superseded by Tactile + a clean overview. Use || true since the exact
+# preinstalled set varies between Kali images.
+gnome-extensions disable pop-shell@system76.com || true
+gnome-extensions disable ding@rastersoft.com || true
 
 # Pause to assure user is ready to accept confirmations
 gum confirm "To install Gnome extensions, you need to accept some confirmations. Ready?"

--- a/install/desktop/ulauncher.sh
+++ b/install/desktop/ulauncher.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
-sudo add-apt-repository universe -y
-sudo add-apt-repository ppa:agornostal/ulauncher -y
-sudo apt update
-sudo apt install ulauncher -y
+# ulauncher is in Debian sid / Kali rolling. Fall back to upstream .deb if missing.
+if ! sudo apt install -y ulauncher; then
+  echo "ulauncher not in apt repo; falling back to upstream GitHub .deb release"
+  cd /tmp
+  ULAUNCHER_DEB_URL=$(curl -fsSL https://api.github.com/repos/Ulauncher/Ulauncher/releases/latest \
+    | grep -oE '"browser_download_url":[[:space:]]*"[^"]+_all\.deb"' \
+    | head -n1 | cut -d'"' -f4)
+  if [ -n "$ULAUNCHER_DEB_URL" ]; then
+    wget -qO ulauncher.deb "$ULAUNCHER_DEB_URL"
+    sudo apt install -y ./ulauncher.deb
+    rm -f ulauncher.deb
+  else
+    echo "Could not locate a ulauncher .deb on GitHub; skipping ulauncher install."
+    cd - >/dev/null
+    return 0 2>/dev/null || exit 0
+  fi
+  cd - >/dev/null
+fi
 
 # Start ulauncher to have it populate config before we overwrite
 mkdir -p ~/.config/autostart/

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-# Display system information in the terminal
-sudo add-apt-repository -y ppa:zhangsongcui3371/fastfetch
-sudo apt update -y
+# Display system information in the terminal (fastfetch is in the Kali rolling repo)
 sudo apt install -y fastfetch
 
 # Only attempt to set configuration if fastfetch is not already set

--- a/install/terminal/docker.sh
+++ b/install/terminal/docker.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
-# Add the official Docker repo
+# Add the official Docker repo (Debian repo + bookworm codename for Kali rolling).
+# Kali's own VERSION_CODENAME is "kali-rolling" which Docker doesn't publish for,
+# so we pin to bookworm per Kali community guidance.
+DOCKER_CODENAME="${DOCKER_CODENAME:-bookworm}"
 if [ ! -f /etc/apt/sources.list.d/docker.list ]; then
     [ -f /etc/apt/keyrings/docker.asc ] && sudo rm /etc/apt/keyrings/docker.asc
     sudo install -m 0755 -d /etc/apt/keyrings
-    sudo wget -qO /etc/apt/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg
+    sudo wget -qO /etc/apt/keyrings/docker.asc https://download.docker.com/linux/debian/gpg
     sudo chmod a+r /etc/apt/keyrings/docker.asc
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${DOCKER_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 fi
 
 # Install Docker engine and standard plugins

--- a/install/terminal/libraries.sh
+++ b/install/terminal/libraries.sh
@@ -4,4 +4,4 @@ sudo apt install -y \
   build-essential pkg-config autoconf bison clang rustc pipx \
   libssl-dev libreadline-dev zlib1g-dev libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libjemalloc2 \
   libvips imagemagick libmagickwand-dev mupdf mupdf-tools \
-  redis-tools sqlite3 libsqlite3-0 libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common
+  redis-tools sqlite3 libsqlite3-0 default-libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common

--- a/setup-local.sh
+++ b/setup-local.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Install Omakub from a local checkout (no GitHub clone).
+# Usage: bash /path/to/omakub/setup-local.sh
+#
+# Most installer scripts assume Omakub lives at ~/.local/share/omakub.
+# This script symlinks the current checkout there so those paths resolve.
+
+set -e
+
+# Refuse to run via sudo. Running as root puts every per-user file (pipx envs,
+# GNOME extensions, dotfiles, etc.) under /root, and gext cannot reach the
+# GNOME Shell session DBus from root's session bus. The installer escalates
+# privilege with `sudo` itself when needed.
+if [ -n "$SUDO_USER" ] && [ "$EUID" -eq 0 ]; then
+  echo "Error: Do not run setup-local.sh with sudo." >&2
+  echo "Run as your normal (non-root) user; the installer will sudo when needed." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+TARGET="$HOME/.local/share/omakub"
+
+ascii_art='________                  __        ___.
+\_____  \   _____ _____  |  | ____ _\_ |__
+ /   |   \ /     \\__   \ |  |/ /  |  \ __ \
+/    |    \  Y Y  \/ __ \|    <|  |  / \_\ \
+\_______  /__|_|  (____  /__|_ \____/|___  /
+        \/      \/     \/     \/         \/
+'
+
+echo -e "$ascii_art"
+echo "=> Omakub (Kali Linux 2025.1+ GNOME edition)"
+echo "   Source checkout: $SCRIPT_DIR"
+
+mkdir -p "$(dirname "$TARGET")"
+
+TARGET_CANON="$(readlink -f "$TARGET" 2>/dev/null || echo "$TARGET")"
+
+if [ "$SCRIPT_DIR" = "$TARGET_CANON" ]; then
+  echo "   Project is already at $TARGET; no symlink needed."
+elif [ -L "$TARGET" ]; then
+  if [ "$TARGET_CANON" = "$SCRIPT_DIR" ]; then
+    echo "   $TARGET already linked to this checkout."
+  else
+    echo "   Repointing existing symlink $TARGET -> $SCRIPT_DIR (was $TARGET_CANON)."
+    rm "$TARGET"
+    ln -s "$SCRIPT_DIR" "$TARGET"
+  fi
+elif [ -e "$TARGET" ]; then
+  BACKUP="${TARGET}.bak-$(date +%s)"
+  echo "   $TARGET exists and is not a symlink; moving aside to $BACKUP."
+  mv "$TARGET" "$BACKUP"
+  ln -s "$SCRIPT_DIR" "$TARGET"
+else
+  ln -s "$SCRIPT_DIR" "$TARGET"
+  echo "   Created symlink $TARGET -> $SCRIPT_DIR."
+fi
+
+echo -e "\nBegin installation (or abort with ctrl+c)..."
+sudo apt-get update >/dev/null
+sudo apt-get install -y git >/dev/null
+
+echo "Installation starting..."
+source "$TARGET/install.sh"

--- a/themes/set-vscode-theme.sh
+++ b/themes/set-vscode-theme.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 if command -v code &>/dev/null; then
-  code --install-extension $VSC_EXTENSION >/dev/null
+  # See install/desktop/app-vscode.sh for why --disable-telemetry + timeout.
+  timeout 180 code --install-extension "$VSC_EXTENSION" --disable-telemetry >/dev/null || \
+    echo "Warning: VS Code theme extension install failed or timed out; continuing."
   sed -i "s/\"workbench.colorTheme\": \".*\"/\"workbench.colorTheme\": \"$VSC_THEME\"/g" ~/.config/Code/User/settings.json
 fi

--- a/uninstall/app-mainline-kernels.sh
+++ b/uninstall/app-mainline-kernels.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sudo apt remove -y mainline

--- a/uninstall/app-rubymine.sh
+++ b/uninstall/app-rubymine.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sudo snap remove rubymine


### PR DESCRIPTION
Port the Ubuntu-based Omakub installer to work on Kali Linux rolling. Key changes: replace Ubuntu version checks with Kali detection, use Debian Docker repos pinned to bookworm, install fastfetch and ulauncher from Kali repos (with GitHub fallback for ulauncher), disable Kali's pop-shell and ding extensions instead of Ubuntu's, remove snap-based apps (RubyMine) and Ubuntu-specific tools (Mainline Kernels PPA), add setup-local.sh for installing from a local checkout, prevent running under sudo to avoid corru