### PR TITLE
Fix: space-bar extension schemas split into 4 files

### DIFF
--- a/install/desktop/set-gnome-extensions.sh
+++ b/install/desktop/set-gnome-extensions.sh
@@ -25,7 +25,10 @@ gext install AlphabeticalAppGrid@stuarthayhurst
 sudo cp ~/.local/share/gnome-shell/extensions/tactile@lundal.io/schemas/org.gnome.shell.extensions.tactile.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/just-perfection-desktop\@just-perfection/schemas/org.gnome.shell.extensions.just-perfection.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/blur-my-shell\@aunetx/schemas/org.gnome.shell.extensions.blur-my-shell.gschema.xml /usr/share/glib-2.0/schemas/
-sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.appearance.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.behavior.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml /usr/share/glib-2.0/schemas/
+sudo cp ~/.local/share/gnome-shell/extensions/space-bar\@luchrioh/schemas/org.gnome.shell.extensions.space-bar.state.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/tophat@fflewddur.github.io/schemas/org.gnome.shell.extensions.tophat.gschema.xml /usr/share/glib-2.0/schemas/
 sudo cp ~/.local/share/gnome-shell/extensions/AlphabeticalAppGrid\@stuarthayhurst/schemas/org.gnome.shell.extensions.AlphabeticalAppGrid.gschema.xml /usr/share/glib-2.0/schemas/
 sudo glib-compile-schemas /usr/share/glib-2.0/schemas/


### PR DESCRIPTION
## Problem

The installation fails with:

```
cp: cannot stat '~/.local/share/gnome-shell/extensions/space-bar@luchrioh/schemas/org.gnome.shell.extensions.space-bar.gschema.xml': No such file or directory
```

The `space-bar@luchrioh` extension no longer ships a single monolithic schema file. Its GSettings schemas are now split into four separate files:

- `org.gnome.shell.extensions.space-bar.appearance.gschema.xml`
- `org.gnome.shell.extensions.space-bar.behavior.gschema.xml`
- `org.gnome.shell.extensions.space-bar.shortcuts.gschema.xml`
- `org.gnome.shell.extensions.space-bar.state.gschema.xml`

This was verified against the [upstream repository](https://github.com/christopher-l/space-bar) via the GitHub API — the old single file never existed in the current codebase.

## Fix

Replace the single `cp` command with four commands, one per schema file.

## Tested on

- Ubuntu 26.04 LTS (Resolute Raccoon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)