### PR TITLE
Suppress VS Code CLI deprecation warnings during theme setup

### DIFF
--- a/install/desktop/app-vscode.sh
+++ b/install/desktop/app-vscode.sh
@@ -17,4 +17,4 @@ mkdir -p ~/.config/Code/User
 cp ~/.local/share/omakub/configs/vscode.json ~/.config/Code/User/settings.json
 
 # Install default supported themes
-code --install-extension enkia.tokyo-night
+NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation" code --install-extension enkia.tokyo-night

--- a/install/desktop/app-vscode.sh
+++ b/install/desktop/app-vscode.sh
@@ -16,5 +16,7 @@ sudo apt install -y code
 mkdir -p ~/.config/Code/User
 cp ~/.local/share/omakub/configs/vscode.json ~/.config/Code/User/settings.json
 
+CODE_NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
+
 # Install default supported themes
-NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation" code --install-extension enkia.tokyo-night
+NODE_OPTIONS="$CODE_NODE_OPTIONS" code --install-extension "enkia.tokyo-night"

--- a/themes/set-vscode-theme.sh
+++ b/themes/set-vscode-theme.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if command -v code &>/dev/null; then
-  code --install-extension $VSC_EXTENSION >/dev/null
+  NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation" code --install-extension "$VSC_EXTENSION" >/dev/null
   sed -i "s/\"workbench.colorTheme\": \".*\"/\"workbench.colorTheme\": \"$VSC_THEME\"/g" ~/.config/Code/User/settings.json
 fi

--- a/themes/set-vscode-theme.sh
+++ b/themes/set-vscode-theme.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+CODE_NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation"
+
 if command -v code &>/dev/null; then
-  NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--no-deprecation" code --install-extension "$VSC_EXTENSION" >/dev/null
+  NODE_OPTIONS="$CODE_NODE_OPTIONS" code --install-extension "$VSC_EXTENSION" >/dev/null
   sed -i "s/\"workbench.colorTheme\": \".*\"/\"workbench.colorTheme\": \"$VSC_THEME\"/g" ~/.config/Code/User/settings.json
 fi


### PR DESCRIPTION
## Summary
- suppress Node deprecation warnings when the VS Code CLI is invoked during theme switching and initial setup

## Motivation
- switching themes was printing Node `DEP0169` warnings from `url.parse()` during VS Code extension installation, which made the workflow noisy