### PR TITLE
Resolve packages, repos and Yaru variants against the running Ubuntu release

### DIFF
--- a/install/check-version.sh
+++ b/install/check-version.sh
@@ -8,8 +8,9 @@ fi
 
 . /etc/os-release
 
-# Check if running on Ubuntu 24.04 or higher
-if [ "$ID" != "ubuntu" ] || [ $(echo "$VERSION_ID >= 24.04" | bc) != 1 ]; then
+# Check if running on Ubuntu 24.04 or higher. dpkg ships on every Ubuntu, unlike bc,
+# which is missing from server and minimal installs.
+if [ "$ID" != "ubuntu" ] || ! dpkg --compare-versions "$VERSION_ID" ge 24.04; then
   echo "$(tput setaf 1)Error: OS requirement not met"
   echo "You are currently running: $ID $VERSION_ID"
   echo "OS required: Ubuntu 24.04 or higher"

--- a/install/desktop/app-gnome-tweak-tool.sh
+++ b/install/desktop/app-gnome-tweak-tool.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-sudo apt install -y gnome-tweak-tool
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# 26.04 dropped the gnome-tweak-tool transitional package
+apt_install_first gnome-tweaks gnome-tweak-tool

--- a/install/desktop/app-wl-clipboard.sh
+++ b/install/desktop/app-wl-clipboard.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Provides a system clipboard interface for Neovim under Wayland
-sudo apt install wl-clipboard
+sudo apt install -y wl-clipboard

--- a/install/desktop/applications.sh
+++ b/install/desktop/applications.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# A fresh Ubuntu has no per-user applications directory until something writes one
+mkdir -p ~/.local/share/applications
+
 for script in ~/.local/share/omakub/applications/*.sh; do source $script; done

--- a/install/desktop/optional/app-cursor.sh
+++ b/install/desktop/optional/app-cursor.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# jq parses the download URL out of Cursor's API and is not installed by default
+sudo apt install -y jq fuse3
+apt_install_first libfuse2t64 libfuse2
+
 cd /tmp
 curl -L "https://www.cursor.com/api/download?platform=linux-x64&releaseTrack=stable" | jq -r '.downloadUrl' | xargs curl -L -o cursor.appimage
 sudo mv cursor.appimage /opt/cursor.appimage
 sudo chmod +x /opt/cursor.appimage
-sudo apt install -y fuse3
-sudo apt install -y libfuse2t64
 
 DESKTOP_FILE="/usr/share/applications/cursor.desktop"
 

--- a/install/desktop/optional/app-mainline-kernels.sh
+++ b/install/desktop/optional/app-mainline-kernels.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-sudo add-apt-repository -y ppa:cappelikan/ppa
-sudo apt update -y
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+if ! add_ppa_if_published ppa:cappelikan/ppa mainline; then
+	omakub_note "skipping Mainline; the PPA has no build for this Ubuntu release yet"
+	return 0 2>/dev/null || exit 0
+fi
+
 sudo apt install -y mainline

--- a/install/desktop/set-app-grid.sh
+++ b/install/desktop/set-app-grid.sh
@@ -22,7 +22,10 @@ gsettings set org.gnome.desktop.app-folders folder-children "['Utilities', 'Sund
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Updates/ name 'Install & Update'
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Updates/ apps "['org.gnome.Software.desktop', 'software-properties-drivers.desktop', 'software-properties-gtk.desktop', 'update-manager.desktop', 'firmware-updater_firmware-updater.desktop', 'snap-store_snap-store.desktop']"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Xtra/ name 'Xtra'
-gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Xtra/ apps "['org.Characters.desktop', 'gnome-language-selector.desktop', 'org.gnome.PowerStats.desktop', 'org.gnome.Logs.desktop', 'yelp.desktop', 'org.gnome.Yelp.desktop', 'org.gnome.eog.desktop', 'org.gnome.Sysprof.desktop' ]"
+# Both the old and new ids are listed where Gnome renamed an app (Characters gained
+# its org.gnome prefix, Eye of Gnome became Loupe, Yelp gained one), so the folder
+# works whichever release is underneath. Ids with no installed app are ignored.
+gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/Xtra/ apps "['org.Characters.desktop', 'org.gnome.Characters.desktop', 'gnome-language-selector.desktop', 'org.gnome.PowerStats.desktop', 'org.gnome.Logs.desktop', 'yelp.desktop', 'org.gnome.Yelp.desktop', 'org.gnome.eog.desktop', 'org.gnome.Loupe.desktop', 'org.gnome.Sysprof.desktop' ]"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/LibreOffice/ name 'LibreOffice'
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/LibreOffice/ apps "['libreoffice-base.desktop', 'libreoffice-calc.desktop', 'libreoffice-draw.desktop', 'libreoffice-impress.desktop', 'libreoffice-math.desktop', 'libreoffice-startcenter.desktop', 'libreoffice-writer.desktop', 'libreoffice-xsltfilter.desktop']"
 gsettings set org.gnome.desktop.app-folders.folder:/org/gnome/desktop/app-folders/folders/WebApps/ name 'Web Apps'

--- a/install/desktop/set-framework-text-scaling.sh
+++ b/install/desktop/set-framework-text-scaling.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 
-COMPUTER_MAKER=$(sudo dmidecode -t system | grep 'Manufacturer:' | awk '{print $2}')
-SCREEN_RESOLUTION=$(xrandr | grep '*+' | awk '{print $1}')
+# Detection needs dmidecode and a running X or XWayland server. 26.04 has no X11
+# session at all, so let both lookups come back empty rather than reporting errors
+# on the machines this does not apply to.
+COMPUTER_MAKER=$(sudo dmidecode -t system 2>/dev/null | awk '/Manufacturer:/ {print $2}')
+SCREEN_RESOLUTION=$(xrandr 2>/dev/null | awk '/\*\+/ {print $1}')
 
 if [ "$COMPUTER_MAKER" == "Framework" ] && [ "$SCREEN_RESOLUTION" == "2256x1504" ]; then
 	gsettings set org.gnome.desktop.interface text-scaling-factor 0.8
 	gsettings set org.gnome.desktop.interface cursor-size 16
-	sed -i "s/size = 9/size = 7/g" ~/.config/alacritty/alacritty.toml
+
+	# The terminal font size lives in its own file so every Omakub terminal app shares it
+	sed -i "s/^size = .*$/size = 7/" ~/.config/alacritty/font-size.toml
 fi

--- a/install/desktop/ulauncher.sh
+++ b/install/desktop/ulauncher.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
 sudo add-apt-repository universe -y
-sudo add-apt-repository ppa:agornostal/ulauncher -y
-sudo apt update
+
+# Ulauncher is only in the PPA, so stop here with a clear message rather than a
+# confusing apt failure if it has not built for this Ubuntu release yet.
+if ! add_ppa_if_published ppa:agornostal/ulauncher ulauncher; then
+	omakub_note "skipping Ulauncher; rerun 'omakub install' once the PPA catches up"
+	return 0 2>/dev/null || exit 0
+fi
+
 sudo apt install ulauncher -y
 
 # Start ulauncher to have it populate config before we overwrite

--- a/install/lib/compat.sh
+++ b/install/lib/compat.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# Compatibility helpers for running Omakub across Ubuntu releases.
+#
+# Ubuntu renames, drops, and re-splits packages between releases, Yaru ships a
+# different set of accent variants each cycle, and third-party repositories only
+# publish for a codename some months after that release ships. Hardcoding names
+# that were correct for one release is what breaks Omakub on the next one, so the
+# installers ask these helpers what is actually available on the running system.
+
+[ -n "${OMAKUB_COMPAT_LOADED:-}" ] && return 0
+OMAKUB_COMPAT_LOADED=1
+
+omakub_note() { echo "Omakub: $*"; }
+
+omakub_os_release() {
+	local key=$1
+	(. /etc/os-release && printf '%s' "${!key}")
+}
+
+omakub_ubuntu_codename() { omakub_os_release UBUNTU_CODENAME; }
+omakub_ubuntu_version() { omakub_os_release VERSION_ID; }
+
+# Ubuntu codenames released before the running one, newest first. Lets a repo that
+# has not published for this release yet fall back to the newest suite it does have.
+omakub_older_codenames() {
+	local csv=/usr/share/distro-info/ubuntu.csv
+	[ -f "$csv" ] || return 0
+
+	awk -F, -v current="$(omakub_ubuntu_version)" '
+		NR > 1 {
+			split($1, release, " ")
+			if (release[1] + 0 < current + 0) print release[1] "," $3
+		}
+	' "$csv" | sort -t, -k1,1Vr | cut -d, -f2
+}
+
+# --- apt -------------------------------------------------------------------
+
+# True when apt has an installation candidate for the package on this release.
+apt_available() {
+	[ -n "$(apt-cache policy -- "$1" 2>/dev/null | awk -F': ' '/Candidate:/ && $2 != "(none)" {print $2}')" ]
+}
+
+# Echo the first of several package names that this release actually ships.
+apt_first_available() {
+	local package
+	for package in "$@"; do
+		if apt_available "$package"; then
+			printf '%s' "$package"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Install the first package name that exists here, so a rename between releases
+# (libncurses5-dev -> libncurses-dev) does not abort the installer.
+apt_install_first() {
+	local package
+	if package=$(apt_first_available "$@"); then
+		sudo apt install -y "$package"
+	else
+		omakub_note "none of these packages exist on $(omakub_ubuntu_codename): $*" >&2
+		return 1
+	fi
+}
+
+# --- repositories ----------------------------------------------------------
+
+# True when an apt repository publishes a Release file for the given suite.
+repo_publishes_suite() {
+	curl --silent --fail --location --max-time 15 --output /dev/null \
+		"${1%/}/dists/$2/Release"
+}
+
+# Newest suite a codename-keyed repository publishes, starting at this release and
+# walking back through older Ubuntu codenames. Docker in particular lags new releases.
+repo_best_suite() {
+	local base_url=$1 suite
+
+	for suite in "$(omakub_ubuntu_codename)" $(omakub_older_codenames); do
+		if repo_publishes_suite "$base_url" "$suite"; then
+			printf '%s' "$suite"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+# True when a Launchpad PPA has a build of the package for this Ubuntu series.
+# Launchpad serves an empty index for series a PPA never built for, so checking
+# the Release file alone is not enough.
+ppa_publishes_package() {
+	local ppa=${1#ppa:} package=$2 series=${3:-$(omakub_ubuntu_codename)}
+
+	curl --silent --fail --location --max-time 20 \
+		"https://ppa.launchpadcontent.net/${ppa%%/*}/${ppa#*/}/ubuntu/dists/$series/main/binary-$(dpkg --print-architecture)/Packages.gz" |
+		gunzip 2>/dev/null | grep -qx "Package: $package"
+}
+
+# Add a PPA only when it has a build for this release, so callers can fall back to
+# the Ubuntu archive instead of leaving behind a source that 404s on every apt update.
+add_ppa_if_published() {
+	local ppa=$1 package=$2
+
+	if ppa_publishes_package "$ppa" "$package"; then
+		sudo add-apt-repository -y "$ppa"
+		sudo apt update -y
+		return 0
+	fi
+
+	omakub_note "$ppa has no $package build for $(omakub_ubuntu_codename)"
+	return 1
+}
+
+# --- gnome -----------------------------------------------------------------
+
+# gsettings exits non-zero on an unknown schema or key, which aborts the installer
+# whenever Gnome renames one or an extension failed to install.
+gsettings_set_if_available() {
+	local schema=$1 key=$2 value=$3
+
+	if gsettings list-keys "${schema%%:*}" 2>/dev/null | grep -qx -- "$key"; then
+		gsettings set "$schema" "$key" "$value"
+	else
+		omakub_note "skipping unavailable setting ${schema%%:*} $key"
+	fi
+
+	return 0
+}
+
+# Yaru ships a different set of accent variants each cycle: 24.04 had "bark" and
+# "viridian", 25.10 dropped both and added "wartybrown" and "yellow". Map onto a
+# variant this release installs so GTK apps keep the theme's color.
+yaru_variant_for() {
+	local color=$1 candidate candidates
+
+	case $color in
+	bark) candidates="bark wartybrown olive" ;;
+	viridian) candidates="viridian prussiangreen sage" ;;
+	*) candidates="$color" ;;
+	esac
+
+	for candidate in $candidates; do
+		if [ -d "/usr/share/themes/Yaru-$candidate-dark" ] && [ -d "/usr/share/icons/Yaru-$candidate" ]; then
+			printf '%s' "$candidate"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+# Gnome 47+ exposes a fixed accent-color enum whose names do not all match Yaru's
+# variants. Translate so every theme gets an accent, not just the ones whose name
+# happens to appear in both lists.
+gnome_accent_for() {
+	local accent
+
+	case $1 in
+	magenta) accent=pink ;;
+	sage) accent=green ;;
+	bark) accent=brown ;;
+	grey) accent=slate ;;
+	*) accent=$1 ;;
+	esac
+
+	if gsettings range org.gnome.desktop.interface accent-color 2>/dev/null | grep -qx -- "'$accent'"; then
+		printf '%s' "$accent"
+		return 0
+	fi
+
+	return 1
+}

--- a/install/terminal/app-fastfetch.sh
+++ b/install/terminal/app-fastfetch.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
-# Display system information in the terminal
-sudo add-apt-repository -y ppa:zhangsongcui3371/fastfetch
-sudo apt update -y
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Display system information in the terminal. The PPA tracks upstream far more
+# closely than the archive, but it does not always have a build the day a new
+# Ubuntu ships; 26.04 carries fastfetch in universe, so fall back there rather
+# than leaving behind a source that breaks every later apt update.
+add_ppa_if_published ppa:zhangsongcui3371/fastfetch fastfetch || true
+
 sudo apt install -y fastfetch
 
 # Only attempt to set configuration if fastfetch is not already set

--- a/install/terminal/docker.sh
+++ b/install/terminal/docker.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
 # Add the official Docker repo
 if [ ! -f /etc/apt/sources.list.d/docker.list ]; then
+    # Docker publishes per Ubuntu codename and only some months after a release
+    # ships. Fall back to the newest suite it does carry rather than writing a
+    # source that 404s and breaks every later apt update.
+    DOCKER_SUITE=$(repo_best_suite https://download.docker.com/linux/ubuntu) || {
+        omakub_note "Docker has no repo for $(omakub_ubuntu_codename) or any earlier release" >&2
+        return 1 2>/dev/null || exit 1
+    }
+
+    if [ "$DOCKER_SUITE" != "$(omakub_ubuntu_codename)" ]; then
+        omakub_note "Docker has no $(omakub_ubuntu_codename) repo yet, using $DOCKER_SUITE"
+    fi
+
     [ -f /etc/apt/keyrings/docker.asc ] && sudo rm /etc/apt/keyrings/docker.asc
     sudo install -m 0755 -d /etc/apt/keyrings
     sudo wget -qO /etc/apt/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg
     sudo chmod a+r /etc/apt/keyrings/docker.asc
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $DOCKER_SUITE stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
 fi
 
 # Install Docker engine and standard plugins

--- a/install/terminal/libraries.sh
+++ b/install/terminal/libraries.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
 sudo apt install -y \
   build-essential pkg-config autoconf bison clang rustc pipx \
-  libssl-dev libreadline-dev zlib1g-dev libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev libjemalloc2 \
-  libvips imagemagick libmagickwand-dev mupdf mupdf-tools \
+  libssl-dev libreadline-dev zlib1g-dev libyaml-dev libffi-dev libgdbm-dev libjemalloc2 \
+  imagemagick libmagickwand-dev mupdf mupdf-tools \
   redis-tools sqlite3 libsqlite3-0 libmysqlclient-dev libpq-dev postgresql-client postgresql-client-common
+
+# 26.04 folded libncurses5-dev into libncurses-dev, and dropped the plain libvips
+# package in favour of the t64 runtime that libvips-tools pulls in.
+apt_install_first libncurses-dev libncurses5-dev
+apt_install_first libvips-tools libvips

--- a/migrations/1785277200.sh
+++ b/migrations/1785277200.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Repair an Omakub install that has been carried onto Ubuntu 26.04, which renamed
+# some of the packages Omakub installs and reshuffled Yaru's accent variants.
+
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+echo "Reinstalling packages that were renamed in Ubuntu 26.04..."
+apt_install_first gnome-tweaks gnome-tweak-tool
+apt_install_first libncurses-dev libncurses5-dev
+apt_install_first libvips-tools libvips
+
+# 26.04 dropped the Yaru "bark" and "viridian" accents, so any theme using one is now
+# pointing at a gtk-theme that is not installed and has fallen back to stock Ubuntu.
+CURRENT_GTK_THEME=$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d "'")
+
+if [[ "$CURRENT_GTK_THEME" == Yaru-*-dark ]] && [ ! -d "/usr/share/themes/$CURRENT_GTK_THEME" ]; then
+	THEME_COLOR=${CURRENT_GTK_THEME#Yaru-}
+	THEME_COLOR=${THEME_COLOR%-dark}
+
+	if YARU_VARIANT=$(yaru_variant_for "$THEME_COLOR"); then
+		echo "Repointing Gnome theme from $CURRENT_GTK_THEME to Yaru-$YARU_VARIANT-dark"
+		gsettings set org.gnome.desktop.interface gtk-theme "Yaru-$YARU_VARIANT-dark"
+		gsettings set org.gnome.desktop.interface icon-theme "Yaru-$YARU_VARIANT"
+	fi
+
+	if GNOME_ACCENT=$(gnome_accent_for "$THEME_COLOR"); then
+		gsettings_set_if_available org.gnome.desktop.interface accent-color "$GNOME_ACCENT"
+	fi
+fi

--- a/themes/catppuccin/tophat.sh
+++ b/themes/catppuccin/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#e920a3"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#e920a3"

--- a/themes/everforest/tophat.sh
+++ b/themes/everforest/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"

--- a/themes/gruvbox/tophat.sh
+++ b/themes/gruvbox/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#78ab50"

--- a/themes/kanagawa/tophat.sh
+++ b/themes/kanagawa/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"

--- a/themes/matte-black/tophat.sh
+++ b/themes/matte-black/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#FFFFFF"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#FFFFFF"

--- a/themes/nord/tophat.sh
+++ b/themes/nord/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#208fe9"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#208fe9"

--- a/themes/osaka-jade/tophat.sh
+++ b/themes/osaka-jade/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#214237"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#214237"

--- a/themes/ristretto/tophat.sh
+++ b/themes/ristretto/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#2c2525"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#2c2525"

--- a/themes/rose-pine/tophat.sh
+++ b/themes/rose-pine/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#e92020"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#e92020"

--- a/themes/set-gnome-theme.sh
+++ b/themes/set-gnome-theme.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
 gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
 gsettings set org.gnome.desktop.interface cursor-theme 'Yaru'
-gsettings set org.gnome.desktop.interface gtk-theme "Yaru-$OMAKUB_THEME_COLOR-dark"
-gsettings set org.gnome.desktop.interface icon-theme "Yaru-$OMAKUB_THEME_COLOR"
-gsettings set org.gnome.desktop.interface accent-color "$OMAKUB_THEME_COLOR" 2>/dev/null || true
+
+# Yaru reshuffles its accent variants between releases: 26.04 dropped "bark" and
+# "viridian" for "wartybrown" and "yellow". Resolve to a variant that is installed,
+# otherwise Gnome silently falls back to stock Ubuntu orange.
+if YARU_VARIANT=$(yaru_variant_for "$OMAKUB_THEME_COLOR"); then
+	gsettings set org.gnome.desktop.interface gtk-theme "Yaru-$YARU_VARIANT-dark"
+	gsettings set org.gnome.desktop.interface icon-theme "Yaru-$YARU_VARIANT"
+else
+	omakub_note "Yaru has no $OMAKUB_THEME_COLOR variant on $(omakub_ubuntu_codename), using the default"
+	gsettings set org.gnome.desktop.interface gtk-theme "Yaru-dark"
+	gsettings set org.gnome.desktop.interface icon-theme "Yaru"
+fi
+
+# Gnome 47+ takes an accent from a fixed enum whose names only partly overlap Yaru's
+if GNOME_ACCENT=$(gnome_accent_for "$OMAKUB_THEME_COLOR"); then
+	gsettings_set_if_available org.gnome.desktop.interface accent-color "$GNOME_ACCENT"
+fi
 
 BACKGROUND_ORG_PATH="$HOME/.local/share/omakub/themes/$OMAKUB_THEME_BACKGROUND"
 BACKGROUND_DEST_DIR="$HOME/.local/share/backgrounds"

--- a/themes/tokyo-night/tophat.sh
+++ b/themes/tokyo-night/tophat.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-gsettings set org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"
+source "${OMAKUB_PATH:-$HOME/.local/share/omakub}/install/lib/compat.sh"
+
+# Skipped rather than errored when TopHat is not installed
+gsettings_set_if_available org.gnome.shell.extensions.tophat meter-fg-color "#924d8b"


### PR DESCRIPTION
Omakub resolves what it installs against names that were correct for 24.04. Four of them no longer exist on 26.04, and Yaru dropped an accent two themes depend on. Swapping in the 26.04 names would just break again on 26.10, so this resolves against whatever the running release actually ships.

Verified on a stock Ubuntu 26.04 (Resolute Raccoon) desktop, GNOME Shell 50.1, and re-checked against 24.04 package data so nothing regresses there.

### Packages that no longer exist on 26.04

| Package | Status |
|---|---|
| `gnome-tweak-tool` | transitional package dropped; the real name has always been `gnome-tweaks` |
| `libncurses5-dev` | folded into `libncurses-dev` |
| `libvips` | runtime is now `libvips42t64`, pulled in by `libvips-tools` |

Each is resolved from a candidate list, so 24.04 and 26.04 both work from the same script.

### Yaru variants and accent-color — fixes #604

24.04 shipped `Yaru-bark` and `Yaru-viridian`; 25.10 dropped both and added `wartybrown` and `yellow`. Everforest was left setting a `gtk-theme` that isn't installed, so GNOME silently fell back to stock Ubuntu orange — no error, just the wrong theme.

Separately, GNOME 47+ takes `accent-color` from a fixed enum (`blue teal green yellow orange red pink purple slate brown`) whose names only partly overlap Yaru's variant names, so `magenta`, `sage`, `bark` and `grey` were being dropped on the floor.

Themes now resolve to a variant that is installed and translate the accent onto a value the enum accepts. As #604 notes, `green`, `orange` and `grey` were never Yaru variant names on any release — those keep falling back to stock Yaru exactly as before, but they now get a sensible accent instead of none.

### Codename-keyed repositories

Docker and the fastfetch, Ulauncher and Mainline PPAs are keyed on the Ubuntu codename and publish for a new release on their own schedule. Adding a source before the vendor has published leaves a 404 that breaks *every later* `apt update`, not just the install.

Each is now checked for a build first. Docker falls back to the newest suite it does carry (walking back through `/usr/share/distro-info/ubuntu.csv`), fastfetch falls back to the archive package — 26.04 carries it in universe — and Ulauncher and Mainline skip with a message telling the user to re-run once the PPA catches up.

All three PPAs do have `resolute` builds today, so this is about the next release rather than this one.

### Smaller fixes found along the way

- `check-version.sh` used `bc`, which server and minimal installs don't have. `dpkg --compare-versions` ships everywhere.
- Framework detection ran `xrandr` unguarded — 26.04 has no X11 session at all. It also wrote the terminal font size to `alacritty.toml`, which stopped holding it when `font-size.toml` was split out, so the Framework path had been a no-op for a while.
- `app-wl-clipboard.sh` was missing `-y` and prompted mid-install.
- `app-cursor.sh` pipes the download URL through `jq` without installing it.
- `applications.sh` assumed `~/.local/share/applications` already exists.
- The Xtra app folder lists ids GNOME has renamed (`org.Characters` → `org.gnome.Characters`, Eye of GNOME → Loupe). Both are listed now; ids with no installed app are ignored by GNOME.
- TopHat's theme colour and the `accent-color` write now skip cleanly when the schema is absent, instead of erroring out of a theme switch when the extension isn't installed.

### Scope

Deliberately **does not touch** `select-dev-language.sh`, `uninstall/dev-language.sh` or `set-gnome-extensions.sh` — #600 already covers the dev language rewrite and the Space Bar schema split, and I didn't want to collide with it. This should merge cleanly alongside that PR in either order.

`migrations/1785277200.sh` repairs an existing install carried onto 26.04: reinstalls the renamed packages and repoints a theme left on a Yaru variant that is no longer installed.

I also have a non-root preflight checker that verifies every package, repository, PPA, extension, gsettings key, theme variant and download without changing anything — happy to open it as a follow-up if that's of interest, but I left it out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)